### PR TITLE
Support 'sensitive' resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Concourse [resource](https://resource-types.concourse-ci.org/) for retrieving 
 * `filter`: _Optional_. Can contain any/all of the following criteria:
   * `name`: Matches against the `metadata.name` of the resource.  Supports both literal (`my-ns-1`) and regular expressions (`"my-ns-[0-9]*$"`).
   * `olderThan`: Time in seconds that the `metadata.creationTimestamp` must be older than.
-
+* `sensitive`: _Optional._  If `true`, the resource content will be considered sensitive and not show up in the logs or Concourse UI.  Can be overridden as a param to each `get` step. Default is `false`.
 ## Behavior
 
 ### `check`: Check for new k8s resource(s)
@@ -49,6 +49,10 @@ Retrieve the single resource as JSON (`-o json`) and writes it to a file `resour
   ...
 }
 ```
+
+#### Parameters
+
+* `sensitive`: _Optional._  Overrides the source configuration's value for this particular `get`.
 
 ### `out`: no-op (currently)
 

--- a/scripts/check
+++ b/scripts/check
@@ -22,8 +22,8 @@ extractPreviousVersion() {
 }
 
 queryForVersions() {
-    log "\n--> querying k8s cluster for '$resource_types' resources..."
-    new_versions=$(kubectl --server=$url --token=$token --certificate-authority=$ca_file  get $resource_types --all-namespaces --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[].metadata]' )
+    log "\n--> querying k8s cluster for '$source_resource_types' resources..."
+    new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types --all-namespaces --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[].metadata]' )
     log "$new_versions"
 }
 

--- a/scripts/common
+++ b/scripts/common
@@ -44,15 +44,57 @@ log() {
   fi
 }
 
+isTrue() {
+    if notSet $1; then
+        return 1;
+    else
+        eval varVal=\$$1;
+        if ! [[ $varVal = true ]]; then
+            return 1;
+        fi
+    fi
+}
+
+notTrue() {
+    if ! notSet $1; then
+        eval varVal=\$$1;
+        if [[ $varVal = true ]]; then
+            return 1;
+        fi
+    fi
+}
+
+isSet() {
+    eval varVal=\$$1;
+    if [ -z "$varVal" ]; then return 1; fi
+    return 0;
+}
+
+notSet() {
+    eval varVal=\$$1;
+    if [ -z "$varVal" ]; then return 0; fi
+    return 1;
+}
+
+isSensitive() {
+    if isTrue params_sensitive; then return 0; fi
+    if isTrue source_sensitive && notSet params_sensitive; then return 0; fi
+    return 1;
+}
+
 payload=$(mktemp /tmp/resource-in.XXXXXX)
 cat > $payload <&0
 
 # source config
-url=$(jq -r '.source.url // ""' < $payload)
-token=$(jq -r '.source.token // ""' < $payload)
-ca=$(jq -r '.source.certificate_authority // ""' < $payload)
-resource_types=$(jq -r '.source.resource_types // "pod"' < $payload)
+source_url=$(jq -r '.source.url // ""' < $payload)
+source_token=$(jq -r '.source.token // ""' < $payload)
+source_ca=$(jq -r '.source.certificate_authority // ""' < $payload)
+source_resource_types=$(jq -r '.source.resource_types // "pod"' < $payload)
+source_sensitive=$(jq -r '.source.sensitive | select(.!=null)' < $payload)
 
 # write the ca file out (have to pass a file ref to kubectl)
-ca_file=$(mktemp /tmp/resource-ca_file.XXXXXX)
-echo "$ca" > "$ca_file"
+source_ca_file=$(mktemp /tmp/resource-ca_file.XXXXXX)
+echo "$source_ca" > "$source_ca_file"
+
+# params config
+params_sensitive=$(jq -r '.params.sensitive  | select(.!=null)' < $payload)

--- a/scripts/in
+++ b/scripts/in
@@ -28,16 +28,17 @@ extractVersion() {
 
 fetchResource() {
     # fetch the requested resource
-    log -p "\nRetrieving ${cyan}${resource_types}${reset} resource ${yellow}'$uid'${reset} at version ${yellow}'$resourceVersion'${reset} from cluster at ${blue}'$url'${reset}..."
-    kubectl --server=$url --token=$token --certificate-authority=$ca_file get $resource_types --all-namespaces --sort-by={.metadata.resourceVersion} -o json \
+    log -p "\nRetrieving ${cyan}${source_resource_types}${reset} resource ${yellow}'$uid'${reset} at version ${yellow}'$resourceVersion'${reset} from cluster at ${blue}'${source_url}'${reset}..."
+    kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file get $source_resource_types --all-namespaces --sort-by={.metadata.resourceVersion} -o json \
           | jq --arg uid $uid --arg resourceVersion $resourceVersion '.items[] | select((.metadata.uid == $uid and .metadata.resourceVersion == $resourceVersion))' \
      > $target_dir/resource.json
 }
 
 emitResult() {
     if [ -s "$target_dir/resource.json" ]; then
-        # TODO config param to control whether this is --public?
-        log -p -j "$(cat $target_dir/resource.json)"
+        if ! isSensitive; then
+            log -j -p "$(cat $target_dir/resource.json)"
+        fi
 
         jq -n "{
           version: {

--- a/test/check.bats
+++ b/test/check.bats
@@ -17,8 +17,8 @@ source_check() {
     export -f log
 
     # mock kubectl to return our expected response
-    local expected_kubectl_args="--server=$url --token=$token --certificate-authority=$ca_file \
-            get $resource_types --all-namespaces --sort-by={.metadata.resourceVersion} -o json"
+    local expected_kubectl_args="--server=$source_url --token=$source_token --certificate-authority=$source_ca_file \
+            get $source_resource_types --all-namespaces --sort-by={.metadata.resourceVersion} -o json"
     stub kubectl "$expected_kubectl_args : cat $BATS_TEST_DIRNAME/fixtures/$kubectl_response.json"
 
     # source the sut

--- a/test/common.bats
+++ b/test/common.bats
@@ -3,56 +3,120 @@
 load '/opt/bats/addons/bats-support/load.bash'
 load '/opt/bats/addons/bats-assert/load.bash'
 
-run_with_full_source() {
-    . "$SUT_SCRIPTS_DIR/common" <<< "$(<$BATS_TEST_DIRNAME/fixtures/stdin-source.json)"
+run_with() {
+    . "$SUT_SCRIPTS_DIR/common" <<< "$(<$BATS_TEST_DIRNAME/fixtures/$1.json)"
 }
 
-run_with_empty_source() {
-    . "$SUT_SCRIPTS_DIR/common" <<< "$(<$BATS_TEST_DIRNAME/fixtures/stdin-source-empty.json)"
+@test "[common] extracts 'source.url' as variable 'source_url'" {
+    run_with "stdin-source"
+    assert isSet source_url
+    assert_equal "$source_url" 'https://some-server:8443'
 }
 
-@test "[common] extracts the url from source config as variable 'url'" {
-    run_with_full_source
-    assert_equal "$url" 'https://some-server:8443'
+@test "[common] extracts 'source.token' as variable 'source_token'" {
+    run_with "stdin-source"
+    assert isSet source_token
+    assert_equal "$source_token" 'a-token'
 }
 
-@test "[common] extracts the token from source config as variable 'token'" {
-    run_with_full_source
-    assert_equal "$token" 'a-token'
+@test "[common] extracts 'source.certificate_authority' as variable 'source_ca'" {
+    run_with "stdin-source"
+    assert isSet source_ca
+    assert_equal "$source_ca" 'a-certificate'
 }
 
-@test "[common] extracts the certificate_authority from source config as variable 'ca'" {
-    run_with_full_source
-    assert_equal "$ca" 'a-certificate'
+@test "[common] writes the content of 'source.certificate_authority' to file 'source_ca_file'" {
+    run_with "stdin-source"
+    assert isSet source_ca_file
+    assert_equal $(head -n 1 $source_ca_file) 'a-certificate'
 }
 
-@test "[common] writes the certificate_authority from source config to file 'ca_file'" {
-    run_with_full_source
-    assert_equal $(head -n 1 $ca_file) 'a-certificate'
+@test "[common] extracts 'source.resource_types' as variable 'source_resource_types'" {
+    run_with "stdin-source"
+    assert isSet source_resource_types
+    assert_equal "$source_resource_types" 'namespaces'
 }
 
-@test "[common] extracts the resource_types from source config as variable 'resource_types'" {
-    run_with_full_source
-    assert_equal "$resource_types" 'namespaces'
+@test "[common] extracts 'source.sensitive' as variable 'source_sensitive'" {
+    run_with "stdin-source-sensitive-true"
+    assert isSet source_sensitive
+    assert_equal "$source_sensitive" 'true'
 }
 
-@test "[common] defaults the url to empty string" {
-    run_with_empty_source
-    assert_equal "$url" ''
+@test "[common] extracts 'params.sensitive' as variable 'params_sensitive'" {
+    run_with "stdin-params-sensitive-true"
+    assert isSet params_sensitive
+    assert_equal "$params_sensitive" 'true'
 }
 
-@test "[common] defaults the token to empty string" {
-    run_with_empty_source
-    assert_equal "$token" ''
+@test "[common] defaults 'source_url' to empty string" {
+    run_with "stdin-source-empty"
+    assert notSet source_url
+    assert_equal "$source_url" ''
 }
 
-@test "[common] defaults the certificate_authority to empty string" {
-    run_with_empty_source
-    assert_equal "$ca" ''
-    assert_equal "$(head -n 1 $ca_file)" ''
+@test "[common] defaults 'source_token' to empty string" {
+    run_with "stdin-source-empty"
+    assert notSet source_token
+    assert_equal "$source_token" ''
 }
 
-@test "[common] defaults the resource_types to 'pod'" {
-    run_with_empty_source
-    assert_equal "$resource_types" 'pod'
+@test "[common] defaults 'source_certificate_authority' to empty string" {
+    run_with "stdin-source-empty"
+    assert notSet source_ca
+    assert_equal "$source_ca" ''
+    assert_equal "$(head -n 1 $source_ca_file)" ''
+}
+
+@test "[common] defaults 'source_resource_types' to 'pod'" {
+    run_with "stdin-source-empty"
+    assert isSet source_resource_types
+    assert_equal "$source_resource_types" 'pod'
+}
+
+@test "[common] defaults 'source_sensitive' to empty" {
+    run_with "stdin-source-empty"
+    assert notSet source_sensitive
+    assert_equal "$source_sensitive" ''
+}
+
+@test "[common] defaults 'params_sensitive' to empty" {
+    run_with "stdin-source-empty"
+    assert notSet params_sensitive
+    assert_equal "$params_sensitive" ''
+}
+
+@test "[common] isSensitive() is true when 'params.sensitive=true'" {
+    run_with "stdin-params-sensitive-true"
+    assert isSensitive
+}
+
+@test "[common] isSensitive() is false when 'params.sensitive=false'" {
+    run_with "stdin-params-sensitive-false"
+    refute isSensitive
+}
+
+@test "[common] isSensitive() is true when 'source.sensitive=true' and 'params.sensitive' is not specified" {
+    run_with "stdin-source-sensitive-true"
+    assert isSensitive
+}
+
+@test "[common] isSensitive() is false when 'source.sensitive=true' and 'params.sensitive=false'" {
+    run_with "stdin-source-sensitive-true-params-sensitive-false"
+    refute isSensitive
+}
+
+@test "[common] isSensitive() is true when 'source.sensitive=true' and 'params.sensitive=true'" {
+    run_with "stdin-source-sensitive-true-params-sensitive-true"
+    assert isSensitive
+}
+
+@test "[common] isSensitive() is true when 'source.sensitive=false' and 'params.sensitive=true'" {
+    run_with "stdin-source-sensitive-false-params-sensitive-true"
+    assert isSensitive
+}
+
+@test "[common] isSensitive() is false when 'source.sensitive=false' and 'params.sensitive=false'" {
+    run_with "stdin-source-sensitive-false-params-sensitive-false"
+    refute isSensitive
 }

--- a/test/fixtures/stdin-params-sensitive-false.json
+++ b/test/fixtures/stdin-params-sensitive-false.json
@@ -1,0 +1,5 @@
+{
+  "params": {
+    "sensitive": false
+  }
+}

--- a/test/fixtures/stdin-params-sensitive-true.json
+++ b/test/fixtures/stdin-params-sensitive-true.json
@@ -1,0 +1,5 @@
+{
+  "params": {
+    "sensitive": true
+  }
+}

--- a/test/fixtures/stdin-source-sensitive-false-params-sensitive-false.json
+++ b/test/fixtures/stdin-source-sensitive-false-params-sensitive-false.json
@@ -1,0 +1,8 @@
+{
+  "source": {
+    "sensitive": false
+  },
+  "params": {
+    "sensitive": false
+  }
+}

--- a/test/fixtures/stdin-source-sensitive-false-params-sensitive-true.json
+++ b/test/fixtures/stdin-source-sensitive-false-params-sensitive-true.json
@@ -1,0 +1,8 @@
+{
+  "source": {
+    "sensitive": false
+  },
+  "params": {
+    "sensitive": true
+  }
+}

--- a/test/fixtures/stdin-source-sensitive-false.json
+++ b/test/fixtures/stdin-source-sensitive-false.json
@@ -1,0 +1,5 @@
+{
+  "source": {
+    "sensitive": false
+  }
+}

--- a/test/fixtures/stdin-source-sensitive-true-params-sensitive-false.json
+++ b/test/fixtures/stdin-source-sensitive-true-params-sensitive-false.json
@@ -1,0 +1,8 @@
+{
+  "source": {
+    "sensitive": true
+  },
+  "params": {
+    "sensitive": false
+  }
+}

--- a/test/fixtures/stdin-source-sensitive-true-params-sensitive-true.json
+++ b/test/fixtures/stdin-source-sensitive-true-params-sensitive-true.json
@@ -1,0 +1,8 @@
+{
+  "source": {
+    "sensitive": true
+  },
+  "params": {
+    "sensitive": true
+  }
+}

--- a/test/fixtures/stdin-source-sensitive-true.json
+++ b/test/fixtures/stdin-source-sensitive-true.json
@@ -1,0 +1,5 @@
+{
+  "source": {
+    "sensitive": true
+  }
+}


### PR DESCRIPTION
Added a new `sensitive` config option to both the `source` and `params`.
If a resource is declared "sensitive", then it will not be emitted to
the logs or be visible in the Concourse web UI.

By default, resources are not sensitive.

When used on the source config,
```yaml
resources:
  - name: my-k8s-resources
    source:
      sensitive: true
```
it will serve as the default for all `get` steps.

However, each `get` can override this,
```yaml
jobs:
  - name: view-resources
    plan:
      - get: my-k8s-resources
        version: every
        trigger: true
        params:
          sensitive: false
```

Closes #1