### PR TITLE
Support configuring namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Concourse [resource](https://resource-types.concourse-ci.org/) for retrieving 
   ```
 
 * `resource_types`: _Optional_. Comma separated list of resource type(s) to retrieve (defaults to just `pod`).
+* `namespace`: _Optional_. The namespace to restrict the query to.  Defaults to all namespaces (`--all-namespaces`).
 * `filter`: _Optional_. Can contain any/all of the following criteria:
   * `name`: Matches against the `metadata.name` of the resource.  Supports both literal (`my-ns-1`) and regular expressions (`"my-ns-[0-9]*$"`).
   * `olderThan`: Time in seconds that the `metadata.creationTimestamp` must be older than.

--- a/scripts/check
+++ b/scripts/check
@@ -23,7 +23,7 @@ extractPreviousVersion() {
 
 queryForVersions() {
     log "\n--> querying k8s cluster for '$source_resource_types' resources..."
-    new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types --all-namespaces --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[].metadata]' )
+    new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types $namespace_arg --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[].metadata]' )
     log "$new_versions"
 }
 

--- a/scripts/common
+++ b/scripts/common
@@ -90,11 +90,19 @@ source_url=$(jq -r '.source.url // ""' < $payload)
 source_token=$(jq -r '.source.token // ""' < $payload)
 source_ca=$(jq -r '.source.certificate_authority // ""' < $payload)
 source_resource_types=$(jq -r '.source.resource_types // "pod"' < $payload)
+source_namespace=$(jq -r '.source.namespace | select(.!=null)' < $payload)
 source_sensitive=$(jq -r '.source.sensitive | select(.!=null)' < $payload)
 
 # write the ca file out (have to pass a file ref to kubectl)
 source_ca_file=$(mktemp /tmp/resource-ca_file.XXXXXX)
 echo "$source_ca" > "$source_ca_file"
+
+# craft a var for specifying the namespace
+if isSet source_namespace; then
+    namespace_arg="-n $source_namespace"
+else
+    namespace_arg="--all-namespaces"
+fi
 
 # params config
 params_sensitive=$(jq -r '.params.sensitive  | select(.!=null)' < $payload)

--- a/scripts/in
+++ b/scripts/in
@@ -28,8 +28,8 @@ extractVersion() {
 
 fetchResource() {
     # fetch the requested resource
-    log -p "\nRetrieving ${cyan}${source_resource_types}${reset} resource ${yellow}'$uid'${reset} at version ${yellow}'$resourceVersion'${reset} from cluster at ${blue}'${source_url}'${reset}..."
-    kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file get $source_resource_types --all-namespaces --sort-by={.metadata.resourceVersion} -o json \
+    log -p "\nRetrieving ${cyan}${source_resource_types}${reset} resource ${yellow}'$uid'${reset} at version ${yellow}'$resourceVersion'${reset} from cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'${source_namespace:---all-namespaces}'${reset}..."
+    kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file get $source_resource_types $namespace_arg --sort-by={.metadata.resourceVersion} -o json \
           | jq --arg uid $uid --arg resourceVersion $resourceVersion '.items[] | select((.metadata.uid == $uid and .metadata.resourceVersion == $resourceVersion))' \
      > $target_dir/resource.json
 }

--- a/test/common.bats
+++ b/test/common.bats
@@ -43,6 +43,24 @@ run_with() {
     assert_equal "$source_sensitive" 'true'
 }
 
+@test "[common] extracts 'source.namespace' as variable 'source_namespace'" {
+    run_with "stdin-source-namespace"
+    assert isSet source_namespace
+    assert_equal "$source_namespace" 'my-namespace'
+}
+
+@test "[common] creates variable 'namespace_arg' with value of '-n \$source_namespace' when 'source.namespace' is configured" {
+    run_with "stdin-source-namespace"
+    assert isSet namespace_arg
+    assert_equal "$namespace_arg" '-n my-namespace'
+}
+
+@test "[common] creates variable 'namespace_arg' with value of '--all-namespaces' when 'source.namespace' is not configured" {
+    run_with "stdin-source"
+    assert isSet namespace_arg
+    assert_equal "$namespace_arg" '--all-namespaces'
+}
+
 @test "[common] extracts 'params.sensitive' as variable 'params_sensitive'" {
     run_with "stdin-params-sensitive-true"
     assert isSet params_sensitive
@@ -72,6 +90,12 @@ run_with() {
     run_with "stdin-source-empty"
     assert isSet source_resource_types
     assert_equal "$source_resource_types" 'pod'
+}
+
+@test "[common] defaults 'source_namespace' to empty" {
+    run_with "stdin-source-empty"
+    assert notSet source_namespace
+    assert_equal "$source_namespace" ''
 }
 
 @test "[common] defaults 'source_sensitive' to empty" {

--- a/test/fixtures/stdin-source-namespace.json
+++ b/test/fixtures/stdin-source-namespace.json
@@ -1,0 +1,9 @@
+{
+  "source": {
+    "url": "https://some-server:8443",
+    "token": "a-token",
+    "certificate_authority": "a-certificate",
+    "resource_types": "namespaces",
+    "namespace": "my-namespace"
+  }
+}


### PR DESCRIPTION
Added support for configuring a namespace to fetch resources from.
Previously it would always use `--all-namespaces`.  Now you can
(optionally) specify the namespace in the source config.

```yaml
resources:
  - name: my-k8s-resources
    source:
      namespace: my-namespace
```

Omitting the `namespace` in the source config defaults to
`--all-namespace` as before.

Closes #2