### PR TITLE
Add 'out' support for executing kubectl commands on a 'put'

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -22,7 +22,11 @@ extractPreviousVersion() {
 }
 
 queryForVersions() {
-    log "\n--> querying k8s cluster for '$source_resource_types' resources..."
+    if notSet namespace_arg; then
+        log "${red}Warning:${reset}  No namespace configured!  Defaulting to ${blue}--all-namespaces${reset}."
+        namespace_arg="--all-namespaces"
+    fi
+    log "\n--> querying k8s cluster ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset} for ${yellow}'${source_resource_types}' resources..."
     new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types $namespace_arg --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[].metadata]' )
     log "$new_versions"
 }

--- a/scripts/common
+++ b/scripts/common
@@ -82,6 +82,11 @@ isSensitive() {
     return 1;
 }
 
+namespace() {
+    # strip the leading '-n ' (if present)
+    echo ${namespace_arg} | sed 's/-n //g'
+}
+
 payload=$(mktemp /tmp/resource-in.XXXXXX)
 cat > $payload <&0
 
@@ -97,12 +102,14 @@ source_sensitive=$(jq -r '.source.sensitive | select(.!=null)' < $payload)
 source_ca_file=$(mktemp /tmp/resource-ca_file.XXXXXX)
 echo "$source_ca" > "$source_ca_file"
 
-# craft a var for specifying the namespace
-if isSet source_namespace; then
-    namespace_arg="-n $source_namespace"
-else
-    namespace_arg="--all-namespaces"
-fi
-
 # params config
+params_kubectl=$(jq -r '.params.kubectl  | select(.!=null)' < $payload)
+params_namespace=$(jq -r '.params.namespace  | select(.!=null)' < $payload)
 params_sensitive=$(jq -r '.params.sensitive  | select(.!=null)' < $payload)
+
+# configure the 'namespace_arg', with the params having highest precedence
+if isSet params_namespace; then
+    namespace_arg="-n $params_namespace"
+elif isSet source_namespace; then
+    namespace_arg="-n $source_namespace"
+fi

--- a/scripts/in
+++ b/scripts/in
@@ -22,13 +22,24 @@ extractVersion() {
     log "\n--> extracting version..."
     version=$(jq -r '.version // ""' < $payload)
     log "Was given version: $version"
-    uid=$(jq -r '.uid // ""' <<< $version)
-    resourceVersion=$(jq -r '.resourceVersion // ""' <<< $version)
+    uid=$(jq -r '.uid | select(.!=null)' <<< $version)
+    resourceVersion=$(jq -r '.resourceVersion | select(.!=null)' <<< $version)
+
+    if [ -z "$uid" ] || [ -z "$resourceVersion" ]; then
+        log "${red}Warning:${reset}  Both 'version.uid' and 'version.resourceVersion' are required to fetch the resource!  If this is the implicit 'get' after a 'put', then this is expected (and can be ignored)."
+        jq -n "{ \"version\": $version }" >&5
+        exit 0
+    fi
 }
 
 fetchResource() {
+    if notSet namespace_arg; then
+        log -p "${red}Warning:${reset}  No namespace configured!  Defaulting to ${blue}--all-namespaces${reset}."
+        namespace_arg="--all-namespaces"
+    fi
+
     # fetch the requested resource
-    log -p "\nRetrieving ${cyan}${source_resource_types}${reset} resource ${yellow}'$uid'${reset} at version ${yellow}'$resourceVersion'${reset} from cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'${source_namespace:---all-namespaces}'${reset}..."
+    log -p "\nRetrieving ${cyan}${source_resource_types}${reset} resource ${yellow}'$uid'${reset} at version ${yellow}'$resourceVersion'${reset} from cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset}..."
     kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file get $source_resource_types $namespace_arg --sort-by={.metadata.resourceVersion} -o json \
           | jq --arg uid $uid --arg resourceVersion $resourceVersion '.items[] | select((.metadata.uid == $uid and .metadata.resourceVersion == $resourceVersion))' \
      > $target_dir/resource.json

--- a/scripts/out
+++ b/scripts/out
@@ -7,15 +7,39 @@ exec 1>&2 # redirect all output to stderr for logging
 
 main() {
     log "\n\n--[OUT]-------------------------"
+    sourcesDirectory $1
+    invokeKubectl
     emitResult
 }
 
+sourcesDirectory() {
+    sources_dir=$1
+    log "\n--> Sources directory is: $sources_dir"
+    cd $sources_dir
+}
+
+invokeKubectl() {
+    if notSet namespace_arg; then
+        log -p "${red}Warning:${reset}  No namespace configured!"
+    fi
+
+    log -p "\nInvoking ${cyan}kubectl${reset} with args ${yellow}'${params_kubectl}'${reset} targeting cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset}..."
+    kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file ${namespace_arg} ${params_kubectl}
+}
+
 emitResult() {
-    jq -n "{
-      version: {
-        not: \"supported\"
-      }
-    }" >&5
+    jq  --arg kubectl "$params_kubectl" \
+        --arg namespace "$(namespace)" \
+        --arg server "$source_url" \
+        -n '{
+      "version": {
+        "kubectl": $kubectl
+      },
+      "metadata": [
+        { "name": "namespace", "value": $namespace },
+        { "name": "server", "value": $server }
+      ]
+    }' >&5
 }
 
 if [ "${BASH_SOURCE[0]}" == "${0}" ]; then

--- a/test/common.bats
+++ b/test/common.bats
@@ -49,22 +49,39 @@ run_with() {
     assert_equal "$source_namespace" 'my-namespace'
 }
 
-@test "[common] creates variable 'namespace_arg' with value of '-n \$source_namespace' when 'source.namespace' is configured" {
-    run_with "stdin-source-namespace"
-    assert isSet namespace_arg
-    assert_equal "$namespace_arg" '-n my-namespace'
+@test "[common] extracts 'params.kubectl' as variable 'params_kubectl'" {
+    run_with "stdin-params-kubectl"
+    assert isSet params_kubectl
+    assert_equal "$params_kubectl" 'apply -k overlays/prod'
 }
 
-@test "[common] creates variable 'namespace_arg' with value of '--all-namespaces' when 'source.namespace' is not configured" {
-    run_with "stdin-source"
-    assert isSet namespace_arg
-    assert_equal "$namespace_arg" '--all-namespaces'
+@test "[common] extracts 'params.namespace' as variable 'params_namespace'" {
+    run_with "stdin-params-namespace"
+    assert isSet params_namespace
+    assert_equal "$params_namespace" 'some-namespace'
 }
 
 @test "[common] extracts 'params.sensitive' as variable 'params_sensitive'" {
     run_with "stdin-params-sensitive-true"
     assert isSet params_sensitive
     assert_equal "$params_sensitive" 'true'
+}
+
+@test "[common] creates variable 'namespace_arg' with value of '-n \$source_namespace' when 'source.namespace' is configured" {
+    run_with "stdin-source-namespace"
+    assert isSet namespace_arg
+    assert_equal "$namespace_arg" '-n my-namespace'
+}
+
+@test "[common] creates variable 'namespace_arg' with value of '-n \$params_namespace' when 'params.namespace' is configured (overrides 'source.namespace')" {
+    run_with "stdin-source-namespace-params-namespace"
+    assert isSet namespace_arg
+    assert_equal "$namespace_arg" '-n my-override-namespace'
+}
+
+@test "[common] does not set variable 'namespace_arg' if neither 'source.namespace' nor 'params.namespace' is configured" {
+    run_with "stdin-source"
+    assert notSet namespace_arg
 }
 
 @test "[common] defaults 'source_url' to empty string" {
@@ -102,6 +119,18 @@ run_with() {
     run_with "stdin-source-empty"
     assert notSet source_sensitive
     assert_equal "$source_sensitive" ''
+}
+
+@test "[common] defaults 'params_kubectl' to empty" {
+    run_with "stdin-source-empty"
+    assert notSet params_kubectl
+    assert_equal "$params_kubectl" ''
+}
+
+@test "[common] defaults 'params_namespace' to empty" {
+    run_with "stdin-source-empty"
+    assert notSet params_namespace
+    assert_equal "$params_namespace" ''
 }
 
 @test "[common] defaults 'params_sensitive' to empty" {
@@ -143,4 +172,24 @@ run_with() {
 @test "[common] isSensitive() is false when 'source.sensitive=false' and 'params.sensitive=false'" {
     run_with "stdin-source-sensitive-false-params-sensitive-false"
     refute isSensitive
+}
+
+@test "[common] namespace() strips the leading '-n' from 'namespace_arg'" {
+    run_with "stdin-source"
+
+    namespace_arg="-n my-ns"
+    assert_equal "my-ns" "$(namespace)"
+}
+
+@test "[common] namespace() leaves '--all-namespaces' as-is" {
+    run_with "stdin-source"
+
+    namespace_arg="--all-namespaces"
+    assert_equal "--all-namespaces" "$(namespace)"
+}
+
+@test "[common] namespace() handles unset 'namespace_arg' as empty string" {
+    run_with "stdin-source"
+
+    assert_equal "" "$(namespace)"
 }

--- a/test/fixtures/stdin-params-kubectl.json
+++ b/test/fixtures/stdin-params-kubectl.json
@@ -1,0 +1,5 @@
+{
+  "params": {
+    "kubectl": "apply -k overlays/prod"
+  }
+}

--- a/test/fixtures/stdin-params-namespace.json
+++ b/test/fixtures/stdin-params-namespace.json
@@ -1,0 +1,5 @@
+{
+  "params": {
+    "namespace": "some-namespace"
+  }
+}

--- a/test/fixtures/stdin-source-namespace-params-kubectl-namespace.json
+++ b/test/fixtures/stdin-source-namespace-params-kubectl-namespace.json
@@ -1,0 +1,13 @@
+{
+  "source": {
+    "url": "https://some-server:8443",
+    "token": "a-token",
+    "certificate_authority": "a-certificate",
+    "resource_types": "namespaces",
+    "namespace": "my-namespace"
+  },
+  "params": {
+    "kubectl": "apply -k overlays/prod",
+    "namespace": "my-override-namespace"
+  }
+}

--- a/test/fixtures/stdin-source-namespace-params-kubectl.json
+++ b/test/fixtures/stdin-source-namespace-params-kubectl.json
@@ -1,0 +1,12 @@
+{
+  "source": {
+    "url": "https://some-server:8443",
+    "token": "a-token",
+    "certificate_authority": "a-certificate",
+    "resource_types": "namespaces",
+    "namespace": "my-namespace"
+  },
+  "params": {
+    "kubectl": "apply -k overlays/prod"
+  }
+}

--- a/test/fixtures/stdin-source-namespace-params-namespace.json
+++ b/test/fixtures/stdin-source-namespace-params-namespace.json
@@ -1,0 +1,12 @@
+{
+  "source": {
+    "url": "https://some-server:8443",
+    "token": "a-token",
+    "certificate_authority": "a-certificate",
+    "resource_types": "namespaces",
+    "namespace": "my-namespace"
+  },
+  "params": {
+    "namespace": "my-override-namespace"
+  }
+}

--- a/test/fixtures/stdin-source-params-kubectl.json
+++ b/test/fixtures/stdin-source-params-kubectl.json
@@ -1,0 +1,11 @@
+{
+  "source": {
+    "url": "https://some-server:8443",
+    "token": "a-token",
+    "certificate_authority": "a-certificate",
+    "resource_types": "namespaces"
+  },
+  "params": {
+    "kubectl": "apply -k overlays/prod"
+  }
+}

--- a/test/fixtures/stdin-source-with-version-no-uid-resourceVersion.json
+++ b/test/fixtures/stdin-source-with-version-no-uid-resourceVersion.json
@@ -1,0 +1,11 @@
+{
+  "source": {
+    "url": "https://some-server:8443",
+    "token": "a-token",
+    "certificate_authority": "a-certificate",
+    "resource_types": "namespaces"
+  },
+  "version": {
+    "something": "else"
+  }
+}

--- a/test/in.bats
+++ b/test/in.bats
@@ -218,3 +218,12 @@ gh1SensitiveTrue() {
     source_in "stdin-source-sensitive-false-params-sensitive-true"
     gh1SensitiveTrue
 }
+
+@test "[in] GH-7 ignores requests without a uid/resourceVersion in the 'version' info given on stdin" {
+    source_in "stdin-source-with-version-no-uid-resourceVersion"
+
+    output=$(extractVersion 5>&1)
+
+    # should emit the version it was given, back out
+    assert_equal "$(jq -r '.version.something' <<< "$output")" 'else'
+}

--- a/test/out.bats
+++ b/test/out.bats
@@ -19,11 +19,92 @@ source_out() {
     source "$SUT_SCRIPTS_DIR/out"
 }
 
-@test "[out] not supported" {
+@test "[out] GH-7 changes into sources directory given" {
     source_out
 
-    output=$(main 5>&1)
+    sourcesDirectory "$BATS_TMPDIR"
 
-    # should emit the version indicating this operation is not (yet) supported
-    assert_equal "$(jq -r '.version.not' <<< "$output")" 'supported'
+    # assert that we changed into the directory
+    assert_equal $BATS_TMPDIR $PWD
+}
+
+@test "[out] GH-7 invoke kubectl with args provided by 'params.kubectl'" {
+    source_out "stdin-source-namespace-params-kubectl"
+
+    # mock kubectl to expect our invocation
+    expected_kubectl_args="--server=$source_url --token=$source_token --certificate-authority=$source_ca_file -n my-namespace apply -k overlays/prod"
+    stub kubectl "$expected_kubectl_args : echo 'stuff the k8s server sends back'"
+
+    output=$(invokeKubectl)
+
+    # verify kubectl was called correctly
+    unstub kubectl
+
+    # should emit the output of kubectl
+    assert_equal "$output" 'stuff the k8s server sends back'
+}
+
+@test "[out] GH-7 uses no namespace when none configured" {
+    source_out "stdin-source-params-kubectl"
+
+    # mock kubectl to expect our invocation
+    expected_kubectl_args="--server=$source_url --token=$source_token --certificate-authority=$source_ca_file apply -k overlays/prod"
+    stub kubectl "$expected_kubectl_args : echo 'stuff the k8s server sends back'"
+
+    output=$(invokeKubectl)
+
+    # verify kubectl was called correctly
+    unstub kubectl
+
+    # should emit the output of kubectl
+    assert_equal "$output" 'stuff the k8s server sends back'
+}
+
+@test "[out] GH-7 can override namespace in params" {
+    source_out "stdin-source-namespace-params-kubectl-namespace"
+
+    # mock kubectl to expect our invocation
+    expected_kubectl_args="--server=$source_url --token=$source_token --certificate-authority=$source_ca_file -n my-override-namespace apply -k overlays/prod"
+    stub kubectl "$expected_kubectl_args : echo 'stuff the k8s server sends back'"
+
+    output=$(invokeKubectl)
+
+    # verify kubectl was called correctly
+    unstub kubectl
+
+    # should emit the output of kubectl
+    assert_equal "$output" 'stuff the k8s server sends back'
+}
+
+@test "[out] GH-7 emits the version as the kubectl command given by 'params.kubectl'" {
+    source_out "stdin-source-namespace-params-kubectl"
+
+    output=$(emitResult 5>&1)
+
+    # should emit the version with the kubectl command executed
+    assert_equal "$(jq -r '.version.kubectl' <<< "$output")" 'apply -k overlays/prod'
+}
+
+@test "[out] GH-7 emits the server url in the output metadata" {
+    source_out "stdin-source-namespace-params-kubectl"
+
+    output=$(emitResult 5>&1)
+
+    assert_equal "$(jq -r '. | any(.metadata[]; .name == "server" and .value == "https://some-server:8443")' <<< "$output")" 'true'
+}
+
+@test "[out] GH-7 emits the namespace in the output metadata" {
+    source_out "stdin-source-namespace-params-kubectl"
+
+    output=$(emitResult 5>&1)
+
+    assert_equal "$(jq -r '. | any(.metadata[]; .name == "namespace" and .value == "my-namespace")' <<< "$output")" 'true'
+}
+
+@test "[out] GH-7 emits empty string for the namespace in the output metadata if it was not configured" {
+    source_out "stdin-source-params-kubectl"
+
+    output=$(emitResult 5>&1)
+
+    assert_equal "$(jq -r '. | any(.metadata[]; .name == "namespace" and .value == "")' <<< "$output")" 'true'
 }


### PR DESCRIPTION
Added a general utility for `out` that executes `kubectl` with args provided as `params` to a `put` step.  For example,

```yaml
      - put: k8s
        params:
          kubectl: apply -f my-k8s-res/deploy.yaml
```

It also supports overriding the `namespace` via a `params.namespace` on the `put` step.

Closes #7