### PR TITLE
Keep entire response payload for filtering purposes during `check`

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -27,7 +27,7 @@ queryForVersions() {
         namespace_arg="--all-namespaces"
     fi
     log "\n--> querying k8s cluster ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset} for ${yellow}'${source_resource_types}' resources..."
-    new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types $namespace_arg --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[].metadata]' )
+    new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types $namespace_arg --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' )
     log "$new_versions"
 }
 
@@ -35,7 +35,7 @@ filterByName() {
     FILTER_NAME=$(jq -r '.source.filter.name // ""' < $payload)
     if [ ! -z "$FILTER_NAME" ]; then
         log "\n--> filtering by name '$FILTER_NAME'..."
-        new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq --arg FILTER_NAME $FILTER_NAME -r '[.[] | select(.name | test($FILTER_NAME))]')
+        new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq --arg FILTER_NAME $FILTER_NAME -r '[.[] | select(.metadata.name | test($FILTER_NAME))]')
         log "$new_versions"
     else
         log "\n--> name filter not configured, skipping...."
@@ -46,7 +46,7 @@ filterByCreationOlderThan() {
     FILTER_OLDER_THAN=$(jq -r '.source.filter.olderThan // ""' < $payload)
     if [ ! -z "$FILTER_OLDER_THAN" ]; then
         log "\n--> filtering by creation timestamp older than '$FILTER_OLDER_THAN'..."
-        new_versions=$(echo $new_versions  | tr '\r\n' ' ' | jq --argjson MAX_AGE $(( $(date +%s) - $FILTER_OLDER_THAN)) -r '[.[] | select(.creationTimestamp | fromdate | tonumber | select(. < $MAX_AGE)) ]')
+        new_versions=$(echo $new_versions  | tr '\r\n' ' ' | jq --argjson MAX_AGE $(( $(date +%s) - $FILTER_OLDER_THAN)) -r '[.[] | select(.metadata.creationTimestamp | fromdate | tonumber | select(. < $MAX_AGE)) ]')
         log "$new_versions"
     else
         log "\n--> creation timestamp (older than) filter not configured, skipping...."
@@ -55,7 +55,7 @@ filterByCreationOlderThan() {
 
 pareDownVersionInfo() {
     log "\n--> pairing down version metadata to just uid/version..."
-    new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq 'map({uid,resourceVersion})')
+    new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq '[.[].metadata] | map({uid,resourceVersion})')
     log "$new_versions"
 }
 

--- a/test/check.bats
+++ b/test/check.bats
@@ -58,60 +58,96 @@ teardown() {
     queryForVersions
 
     assert_equal $(jq length <<< "$new_versions") 3
-    assert_equal "$(jq -r '.[0].name' <<< "$new_versions")" 'namespace-1'
-    assert_equal "$(jq -r '.[1].name' <<< "$new_versions")" 'namespace-2'
-    assert_equal "$(jq -r '.[2].name' <<< "$new_versions")" 'namespace-other'
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-1'
+    assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-2'
+    assert_equal "$(jq -r '.[2].metadata.name' <<< "$new_versions")" 'namespace-other'
 }
 
 @test "[check] filter by name matches exact strings" {
     source_check "stdin-source-filter-name"
 
     new_versions='[
-        { "name": "namespace-1" },
-        { "name": "namespace-2" },
-        { "name": "namespace-other" }
+        {
+            "metadata": {
+                "name": "namespace-1"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-2"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-other"
+            }
+        }
     ]'
 
     filterByName
 
     # then only names exactly matching remain
     assert_equal $(jq length <<< "$new_versions") 1
-    assert_equal "$(jq -r '.[0].name' <<< "$new_versions")" 'namespace-2'
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-2'
 }
 
 @test "[check] filter by name matches regex" {
     source_check "stdin-source-filter-name-regex"
 
     new_versions='[
-        { "name": "namespace-1" },
-        { "name": "namespace-2" },
-        { "name": "namespace-other" }
+        {
+            "metadata": {
+                "name": "namespace-1"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-2"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-other"
+            }
+        }
     ]'
 
     filterByName
 
     # then only names matching the regex remain
     assert_equal $(jq length <<< "$new_versions") 2
-    assert_equal "$(jq -r '.[0].name' <<< "$new_versions")" 'namespace-1'
-    assert_equal "$(jq -r '.[1].name' <<< "$new_versions")" 'namespace-2'
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-1'
+    assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-2'
 }
 
 @test "[check] filter by name not configured" {
     source_check "stdin-source-empty"
 
     new_versions='[
-        { "name": "namespace-1" },
-        { "name": "namespace-2" },
-        { "name": "namespace-other" }
+        {
+            "metadata": {
+                "name": "namespace-1"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-2"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-other"
+            }
+        }
     ]'
 
     filterByName
 
     # then our 'new_versions' is left unchanged
     assert_equal $(jq length <<< "$new_versions") 3
-    assert_equal "$(jq -r '.[0].name' <<< "$new_versions")" 'namespace-1'
-    assert_equal "$(jq -r '.[1].name' <<< "$new_versions")" 'namespace-2'
-    assert_equal "$(jq -r '.[2].name' <<< "$new_versions")" 'namespace-other'
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-1'
+    assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-2'
+    assert_equal "$(jq -r '.[2].metadata.name' <<< "$new_versions")" 'namespace-other'
 }
 
 @test "[check] filter by olderThan" {
@@ -123,16 +159,22 @@ teardown() {
 
     new_versions="[
         {
-            \"name\": \"namespace-1\",
-            \"creationTimestamp\": \"$now\"
+            \"metadata\": {
+                \"name\": \"namespace-1\",
+                \"creationTimestamp\": \"$now\"
+            }
         },
         {
-            \"name\": \"namespace-2\",
-            \"creationTimestamp\": \"$hourAgo\"
+            \"metadata\": {
+                \"name\": \"namespace-2\",
+                \"creationTimestamp\": \"$hourAgo\"
+            }
         },
         {
-            \"name\": \"namespace-3\",
-            \"creationTimestamp\": \"$dayAgo\"
+            \"metadata\": {
+                \"name\": \"namespace-3\",
+                \"creationTimestamp\": \"$dayAgo\"
+            }
         }
     ]"
 
@@ -140,47 +182,68 @@ teardown() {
 
     # then we only have namespaces older than our criteria (24 hours)
     assert_equal $(jq length <<< "$new_versions") 1
-    assert_equal "$(jq -r '.[0].name' <<< "$new_versions")" 'namespace-3'
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-3'
 }
 
 @test "[check] filter by olderThan not configured" {
     source_check "stdin-source-empty"
 
-    new_versions='[
-        { "name": "namespace-1" },
-        { "name": "namespace-2" },
-        { "name": "namespace-other" }
-    ]'
+    new_versions="[
+        {
+            \"metadata\": {
+                \"name\": \"namespace-1\",
+                \"creationTimestamp\": \"$now\"
+            }
+        },
+        {
+            \"metadata\": {
+                \"name\": \"namespace-2\",
+                \"creationTimestamp\": \"$hourAgo\"
+            }
+        },
+        {
+            \"metadata\": {
+                \"name\": \"namespace-3\",
+                \"creationTimestamp\": \"$dayAgo\"
+            }
+        }
+    ]"
 
     filterByCreationOlderThan
 
     # then our 'new_versions' is left unchanged
     assert_equal $(jq length <<< "$new_versions") 3
-    assert_equal "$(jq -r '.[0].name' <<< "$new_versions")" 'namespace-1'
-    assert_equal "$(jq -r '.[1].name' <<< "$new_versions")" 'namespace-2'
-    assert_equal "$(jq -r '.[2].name' <<< "$new_versions")" 'namespace-other'
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-1'
+    assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-2'
+    assert_equal "$(jq -r '.[2].metadata.name' <<< "$new_versions")" 'namespace-3'
 }
 
 @test "[check] pare down version info and emit only uid/resourceVersion" {
     source_check
 
-    new_versions="[
+    new_versions='[
         {
-            \"uid\": \"uid-1\",
-            \"foo\": \"bar-1\",
-            \"resourceVersion\": \"resourceVersion-1\"
+            "metadata": {
+                "uid": "uid-1",
+                "foo": "bar-1",
+                "resourceVersion": "resourceVersion-1"
+            }
         },
         {
-            \"uid\": \"uid-2\",
-            \"foo\": \"bar-2\",
-            \"resourceVersion\": \"resourceVersion-2\"
+            "metadata": {
+                "uid": "uid-2",
+                "foo": "bar-2",
+                "resourceVersion": "resourceVersion-2"
+            }
         },
         {
-            \"uid\": \"uid-3\",
-            \"foo\": \"bar-3\",
-            \"resourceVersion\": \"resourceVersion-3\"
+            "metadata": {
+                "uid": "uid-3",
+                "foo": "bar-3",
+                "resourceVersion": "resourceVersion-3"
+            }
         }
-    ]"
+    ]'
 
     pareDownVersionInfo
 
@@ -304,7 +367,7 @@ teardown() {
     queryForVersions
 
     assert_equal $(jq length <<< "$new_versions") 3
-    assert_equal "$(jq -r '.[0].name' <<< "$new_versions")" 'namespace-1'
-    assert_equal "$(jq -r '.[1].name' <<< "$new_versions")" 'namespace-2'
-    assert_equal "$(jq -r '.[2].name' <<< "$new_versions")" 'namespace-other'
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-1'
+    assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-2'
+    assert_equal "$(jq -r '.[2].metadata.name' <<< "$new_versions")" 'namespace-other'
 }


### PR DESCRIPTION
Small internal refactor of how we manage and keep the response
payload we get back from `kubectl`.  Previously, we immediately
filtered this down to the `items.metadata` for each resource that
came back.  We then passed that subset of the payload to the
various filtering methods.

However, this limited the filtering we could do to only what is
in the `metadata`.

Now, we keep all of the `.items[]` content from the response, and
pass that to our filtering functions.  This gives them the ability
to filter on things other than just what is in the `metadata` of
the resource.

No other features or capabilities have changed or been added in this
commit, it simply paves the way for additional filtering capabilities
(such as #9).