### PR TITLE
Support filtering on `status.phase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,35 @@ with a general purpose `put` for running any `kubectl` command.
   ```
 
 * `resource_types`: _Optional_. Comma separated list of resource type(s) to retrieve (defaults to just `pod`).
+  ```yaml
+    resource_types: deployment,service,pod
+  ```
 * `namespace`: _Optional_. The namespace to restrict the query to. \
   For `check`/`get`, this will default to all namespaces (`--all-namespaces`). \
   For `put`, this will default to remaining unset (not specified), but can be overridden with a step param (see [below](#out-execute-a-kubectl-command)).
 * `filter`: _Optional_. Can contain any/all of the following criteria:
   * `name`: Matches against the `metadata.name` of the resource.  Supports both literal (`my-ns-1`) and regular expressions (`"my-ns-[0-9]*$"`).
-  * `olderThan`: Time in seconds that the `metadata.creationTimestamp` must be older than.
+    ```yaml
+    source:
+      filter:
+        name: "my-ns-[0-9]*$"
+    ```
+  * `olderThan`: Time in seconds that the `metadata.creationTimestamp` must be older than (ex: `86400` for 24hrs).
+    ```yaml
+    source:
+      filter:
+        olderThan: 86400
+    ```
+  * `phases`: List of `phase` value(s) the resource must match at least one of.  This varies depending on the resource.
+    For example, a [pod's status](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) can be
+    one of `Pending`, `Running`, `Succeeded`, `Failed` or `Unknown`.  To retrieve only `Failed` or `Unknown` pods:
+    ```yaml
+    source:
+      filter:
+        phases: 
+          - Failed
+          - Unknown
+    ```
 * `sensitive`: _Optional._  If `true`, the resource content will be considered sensitive and not show up in the logs or Concourse UI.  Can be overridden as a param to each `get` step. Default is `false`.
 ## Behavior
 
@@ -202,6 +225,7 @@ resources:
       filter:
         name: "my-ns-[0-9]*$"
         olderThan: 86400
+        phases: [Active]
 
 jobs:
   - name: delete-expired-namespaces

--- a/assets/check
+++ b/assets/check
@@ -11,6 +11,7 @@ main() {
     queryForVersions
     filterByName
     filterByCreationOlderThan
+    filterByPhases
     pareDownVersionInfo
     emitResult
 }
@@ -26,7 +27,7 @@ queryForVersions() {
         log "${red}Warning:${reset}  No namespace configured!  Defaulting to ${blue}--all-namespaces${reset}."
         namespace_arg="--all-namespaces"
     fi
-    log "\n--> querying k8s cluster ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset} for ${yellow}'${source_resource_types}' resources..."
+    log "\n--> querying k8s cluster ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset} for ${yellow}'${source_resource_types}'${reset} resources..."
     new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types $namespace_arg --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' )
     log "$new_versions"
 }
@@ -50,6 +51,20 @@ filterByCreationOlderThan() {
         log "$new_versions"
     else
         log "\n--> creation timestamp (older than) filter not configured, skipping...."
+    fi
+}
+
+filterByPhases() {
+    FILTER_PHASES=$(jq -r '.source.filter.phases // ""' < $payload)
+    if [ ! -z "$FILTER_PHASES" ]; then
+        # remove any duplicates
+        FILTER_PHASES=$(echo "$FILTER_PHASES" | jq 'unique')
+
+        log "\n--> filtering by phases '$FILTER_PHASES'..."
+        new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq --argjson FILTER_PHASES "$FILTER_PHASES" -r '[.[] | select(.status.phase as $candidate | $FILTER_PHASES[] as $required | $candidate == $required)]')
+        log "$new_versions"
+    else
+        log "\n--> phases filter not configured, skipping...."
     fi
 }
 

--- a/test/check.bats
+++ b/test/check.bats
@@ -371,3 +371,109 @@ teardown() {
     assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-2'
     assert_equal "$(jq -r '.[2].metadata.name' <<< "$new_versions")" 'namespace-other'
 }
+
+@test "[check] GH-9 filter by phases matches exact strings" {
+    source_check "stdin-source-filter-phases"
+
+    new_versions='[
+        {
+            "metadata": {
+                "name": "namespace-1"
+            },
+            "status": {
+                "phase": "Active"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-2"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-3"
+            },
+            "status": {
+                "phase": "Foo"
+            }
+        }
+    ]'
+
+    filterByPhases
+
+    # then only names exactly matching remain
+    assert_equal $(jq length <<< "$new_versions") 2
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-1'
+    assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-3'
+}
+
+@test "[check] GH-9 filter by phases not configured" {
+    source_check "stdin-source-empty"
+
+    new_versions='[
+        {
+            "metadata": {
+                "name": "namespace-1"
+            },
+            "status": {
+                "phase": "Active"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-2"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-3"
+            },
+            "status": {
+                "phase": "Foo"
+            }
+        }
+    ]'
+
+    filterByPhases
+
+    # then only names exactly matching remain
+    assert_equal $(jq length <<< "$new_versions") 3
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-1'
+    assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-2'
+    assert_equal "$(jq -r '.[2].metadata.name' <<< "$new_versions")" 'namespace-3'
+}
+
+@test "[check] GH-9 filter by phases handles duplicates" {
+    source_check "stdin-source-filter-phases-duplicates"
+
+    new_versions='[
+        {
+            "metadata": {
+                "name": "namespace-1"
+            },
+            "status": {
+                "phase": "Active"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-2"
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-3"
+            },
+            "status": {
+                "phase": "Foo"
+            }
+        }
+    ]'
+
+    filterByPhases
+
+    # then only names exactly matching remain
+    assert_equal $(jq length <<< "$new_versions") 2
+    assert_equal "$(jq -r '.[0].metadata.name' <<< "$new_versions")" 'namespace-1'
+    assert_equal "$(jq -r '.[1].metadata.name' <<< "$new_versions")" 'namespace-3'
+}

--- a/test/fixtures/stdin-source-filter-phases-duplicates.json
+++ b/test/fixtures/stdin-source-filter-phases-duplicates.json
@@ -1,0 +1,7 @@
+{
+  "source": {
+    "filter": {
+      "phases": ["Active", "Foo", "Active"]
+    }
+  }
+}

--- a/test/fixtures/stdin-source-filter-phases.json
+++ b/test/fixtures/stdin-source-filter-phases.json
@@ -1,0 +1,7 @@
+{
+  "source": {
+    "filter": {
+      "phases": ["Active", "Foo"]
+    }
+  }
+}


### PR DESCRIPTION
Added support for configuring the `check` to filter on the
`status.phase` value of the retrieve resource.  This is configured like
other filters, in the `source`:

```yaml
    source:
      filter:
        phases: [Running, Succeeded]
```

Closes #9