### PR TITLE
set_images feature on put/out

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -53,7 +53,7 @@ setImages() {
         set +e  # avoid exit on kubectl failure so errors show up, then ...
         echo $IMAGES | jq -r '.[] | [.controller, .container, .image] | @tsv' > $images
         while IFS=$'\t' read -r controller container image; do
-            out=$(kubectl $args set image $controller $container=$image)
+            out=$(kubectl $args set image $controller $container=$image 2>&1)
             [ $? -ne 0 ] && kubectl_failed=1
             if [ -n "$out" ]; then
                 echo "set ${blue}${container}${reset} to ${yellow}${image}${reset}: ${out}"

--- a/assets/out
+++ b/assets/out
@@ -43,14 +43,16 @@ setImages() {
     fi
 
     args="--server=$source_url --token=$source_token --certificate-authority=$source_ca_file ${namespace_arg}"
-    log -p "\nInvoking ${cyan}kubectl${reset} with args ${yellow}'${args}'${reset} targeting cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset}..."
+    log -p "\nInvoking ${cyan}kubectl ... set image ...${reset} targeting cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset}..."
 
     if [ ! -z "$IMAGES" ]; then
         log "\n--> setting images from params..."
         changes=0
         echo $IMAGES | jq -r '.[] | [.controller, .container, .image] | @tsv' |
             while IFS=$'\t' read -r controller container image; do
-                kubectl $args set image $controller $container=$image && changes=$((changes+=1))
+                out=$(kubectl $args set image $controller $container=$image 2>&1)
+                [ -n "$out" ] && echo "set ${blue}${container}${reset} to ${yellow}${image}${reset}: ${out}"
+                changes=$((changes+=1))
             done
 
         report[set_images]="changed $changes images"

--- a/assets/out
+++ b/assets/out
@@ -5,6 +5,8 @@ set -e
 exec 5>&1 # make stdout available as fd 5 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+declare -A report
+
 main() {
     log "\n\n--[OUT]-------------------------"
     sourcesDirectory $1
@@ -20,12 +22,17 @@ sourcesDirectory() {
 }
 
 invokeKubectl() {
-    if notSet namespace_arg; then
-        log -p "${red}Warning:${reset}  No namespace configured!"
-    fi
+    if [ -n "$params_kubectl" ]; then
+        if notSet namespace_arg; then
+            log -p "${red}Warning:${reset}  No namespace configured!"
+        fi
 
-    log -p "\nInvoking ${cyan}kubectl${reset} with args ${yellow}'${params_kubectl}'${reset} targeting cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset}..."
-    kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file ${namespace_arg} ${params_kubectl}
+        log -p "\nInvoking ${cyan}kubectl${reset} with args ${yellow}'${params_kubectl}'${reset} targeting cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset}..."
+        kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file ${namespace_arg} ${params_kubectl}
+        report[kubectl]="${params_kubectl}"
+    else
+        log "\n--> no kubectl parameters specified, skipping...."
+    fi
 }
 
 setImages() {
@@ -40,23 +47,35 @@ setImages() {
 
     if [ ! -z "$IMAGES" ]; then
         log "\n--> setting images from params..."
+        changes=0
         echo $IMAGES | jq -r '.[] | [.controller, .container, .image] | @tsv' |
             while IFS=$'\t' read -r controller container image; do
-                kubectl ${args} set image $controller $container=$image
+                kubectl $args set image $controller $container=$image && changes=$((changes+=1))
             done
+
+        report[set_images]="changed $changes images"
     else
         log "\n--> no images to set specified, skipping...."
     fi
 }
 
 emitResult() {
-    jq  --arg kubectl "$params_kubectl" \
+    if [ "${#report[@]}" -eq 0 ]; then
+        # no key(s) assumes kubectl is what was called
+        version="{\"kubectl\": \"$params_kubectl\"}"
+    else
+        # join the report to a JSON structure being the "out" version
+        for key in "${!report[@]}"; do
+            version=", \"${key}\": \"${report[$key]}\"";
+        done
+        version="{ ${version:2} }"  # chop ', ' at beginning
+    fi
+
+    jq  --argjson version "$version" \
         --arg namespace "$(namespace)" \
         --arg server "$source_url" \
         -n '{
-      "version": {
-        "kubectl": $kubectl
-      },
+      "version": $version,
       "metadata": [
         { "name": "namespace", "value": $namespace },
         { "name": "server", "value": $server }

--- a/assets/out
+++ b/assets/out
@@ -9,6 +9,7 @@ main() {
     log "\n\n--[OUT]-------------------------"
     sourcesDirectory $1
     invokeKubectl
+    setImages
     emitResult
 }
 
@@ -25,6 +26,27 @@ invokeKubectl() {
 
     log -p "\nInvoking ${cyan}kubectl${reset} with args ${yellow}'${params_kubectl}'${reset} targeting cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset}..."
     kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file ${namespace_arg} ${params_kubectl}
+}
+
+setImages() {
+    IMAGES=$(jq -r '.params.set_images // []' < $payload)
+
+    if notSet namespace_arg; then
+        log -p "${red}Warning:${reset}  No namespace configured!"
+    fi
+
+    args="--server=$source_url --token=$source_token --certificate-authority=$source_ca_file ${namespace_arg}"
+    log -p "\nInvoking ${cyan}kubectl${reset} with args ${yellow}'${args}'${reset} targeting cluster at ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset}..."
+
+    if [ ! -z "$IMAGES" ]; then
+        log "\n--> setting images from params..."
+        echo $IMAGES | jq -r '.[] | [.controller, .container, .image] | @tsv' |
+            while IFS=$'\t' read -r controller container image; do
+                kubectl ${args} set image $controller $container=$image
+            done
+    else
+        log "\n--> no images to set specified, skipping...."
+    fi
 }
 
 emitResult() {

--- a/assets/out
+++ b/assets/out
@@ -47,15 +47,28 @@ setImages() {
 
     if [ ! -z "$IMAGES" ]; then
         log "\n--> setting images from params..."
+        images=$(mktemp /tmp/resource-in.images.XXXXXX)
         changes=0
-        echo $IMAGES | jq -r '.[] | [.controller, .container, .image] | @tsv' |
-            while IFS=$'\t' read -r controller container image; do
-                out=$(kubectl $args set image $controller $container=$image 2>&1)
-                [ -n "$out" ] && echo "set ${blue}${container}${reset} to ${yellow}${image}${reset}: ${out}"
+        kubectl_failed=0
+        set +e  # avoid exit on kubectl failure so errors show up, then ...
+        echo $IMAGES | jq -r '.[] | [.controller, .container, .image] | @tsv' > $images
+        while IFS=$'\t' read -r controller container image; do
+            out=$(kubectl $args set image $controller $container=$image)
+            [ $? -ne 0 ] && kubectl_failed=1
+            if [ -n "$out" ]; then
+                echo "set ${blue}${container}${reset} to ${yellow}${image}${reset}: ${out}"
                 changes=$((changes+=1))
-            done
+            fi
+        done < $images
+        set -e
 
-        report[set_images]="changed $changes images"
+        if [ $kubectl_failed -eq 0 ]; then
+            report[set_images]="updated $changes images"
+        else
+            # ... fail the job on any kubectl failure
+            echo 'failed to update (some) images, aborting!'
+            exit 1
+        fi
     else
         log "\n--> no images to set specified, skipping...."
     fi

--- a/test/fixtures/stdin-source-namespace-params-set_images.json
+++ b/test/fixtures/stdin-source-namespace-params-set_images.json
@@ -1,0 +1,16 @@
+{
+  "source": {
+    "url": "https://some-server:8443",
+    "token": "a-token",
+    "certificate_authority": "a-certificate",
+    "resource_types": "namespaces",
+    "namespace": "my-namespace"
+  },
+  "params": {
+    "set_images": [
+       {"controller": "rc/some-controller",  "container": "container1", "image": "image1"},
+       {"controller": "rc/some-controller",  "container": "container2", "image": "image2"},
+       {"controller": "rc/other-controller", "container": "container1", "image": "image1"}
+    ]
+  }
+}

--- a/test/out.bats
+++ b/test/out.bats
@@ -108,3 +108,19 @@ source_out() {
 
     assert_equal "$(jq -r '. | any(.metadata[]; .name == "namespace" and .value == "")' <<< "$output")" 'true'
 }
+
+@test "[out] generates kubectl set image commands from params" {
+    source_out "stdin-source-namespace-params-set_images"
+
+    # mock kubectl to not call the real program... 
+    stub kubectl : 'echo "stuff kubectl may have sent"'
+
+    output=$(setImages)
+
+    # ... since setImages() calls kubectl in a loop there is no way to actually
+    # have the commands checked by the unstub tool (no way I can think of, that is)
+    unstub kubectl || true
+
+    # should emit the output of kubectl
+    assert_equal "$output" 'stuff kubectl may have sent'
+}

--- a/test/out.bats
+++ b/test/out.bats
@@ -122,5 +122,5 @@ source_out() {
     unstub kubectl || true
 
     # should emit the output of kubectl
-    assert_equal "$output" 'stuff kubectl may have sent'
+    assert_equal "$output" "set ${blue}container2${reset} to ${yellow}image2${reset}: stuff kubectl may have sent"
 }


### PR DESCRIPTION
Here is another feature I needed along with the filtering.

My biggest touch on existing code is that the `kubectl` param of `out` had to become optional. Guess it does not matter as who uses it ... uses it. But I don't know.

README.md has two examples. The first could actually be achieved with the `kubectl` param alone. The second shows actual use.

`kubectl` and `set_images` should work complementary cause both can be specified at the same time. I have no use for it yet, but its possible.