### PR TITLE
Fail "check" if kubectl fails

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -24,12 +24,13 @@ extractPreviousVersion() {
 }
 
 queryForVersions() {
+    set -o pipefail
     if notSet namespace_arg; then
         log "${red}Warning:${reset}  No namespace configured!  Defaulting to ${blue}--all-namespaces${reset}."
         namespace_arg="--all-namespaces"
     fi
     log "\n--> querying k8s cluster ${blue}'${source_url}'${reset} in namespace ${blue}'$(namespace)'${reset} for ${yellow}'${source_resource_types}'${reset} resources..."
-    new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types $namespace_arg --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' )
+    new_versions=$(kubectl --server=$source_url --token=$source_token --certificate-authority=$source_ca_file  get $source_resource_types $namespace_arg --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' ) || exit $1
     log "$new_versions"
 }
 


### PR DESCRIPTION
Previously, if `kubectl` returned in error, the subshell (and pipe)
would wind up swallowing that error and returning `0` for the resource
check.

Now, any `kubectl` error is bubbled up and will cause the "check"
operation to fail.  Concourse web will then render this error in the UI
as well.

Closes #12