### PR TITLE
Wrap all custom jq filters in implicit '()'

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -73,7 +73,7 @@ filterByPhases() {
 filterByJQExpressions() {
     FILTER_OPERATOR=$(jq -r '.source.filter.jq_operator // ","' < $payload)
     FILTER_TRANSFORM=$(jq -r '.source.filter.jq_transform // ""' < $payload)
-    FILTER_QUERY=$(jq -r ".source.filter.jq // [] | join(\" ${FILTER_OPERATOR} \") // \"\"" < $payload)
+    FILTER_QUERY=$(jq -r ".source.filter.jq // [] | map(\"(\" + . + \")\") | join(\" ${FILTER_OPERATOR} \") // \"\"" < $payload)
     if [ ! -z "$FILTER_QUERY" ]; then
         log "\n--> filtering by JQ query: '$FILTER_QUERY'"
         if [ -n "$FILTER_TRANSFORM" ]; then

--- a/test/check.bats
+++ b/test/check.bats
@@ -646,6 +646,51 @@ teardown() {
     assert_equal "$(jq -r '.[0].metadata.sum' <<< "$new_versions")" '777'
 }
 
+@test "[check] filter by jq expressions with transformation (no parens)" {
+    source_check "stdin-source-filter-jq-transformation-no-parens"
+
+    new_versions='[
+        {
+            "metadata": {
+                "name": "namespace-1",
+                "number": 111
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-2"
+            },
+            "spec": {
+                "number": 222
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-3",
+                "number": 333
+            },
+            "spec": {
+                "number": 333
+            }
+        },
+        {
+            "metadata": {
+                "name": "namespace-4",
+                "number": 444
+            },
+            "spec": {
+                "number": 444
+            }
+        }
+    ]'
+
+    filterByJQExpressions
+
+    assert_equal "$(jq -r '.[0].metadata.uid' <<< "$new_versions")" 'uuuu-iiii-dddd'
+    assert_equal "$(jq -r '.[0].metadata.resourceVersion' <<< "$new_versions")" '12345'
+    assert_equal "$(jq -r '.[0].metadata.sum' <<< "$new_versions")" '777'
+}
+
 @test "[check] GH-12 exits with error if kubectl fails" {
     source_check "stdin-source" "FAIL"
 

--- a/test/fixtures/stdin-source-filter-jq-transformation-no-parens.json
+++ b/test/fixtures/stdin-source-filter-jq-transformation-no-parens.json
@@ -1,0 +1,12 @@
+{
+  "source": {
+    "filter": {
+      "jq_operator": "or",
+      "jq": [
+         ".metadata | .number==111",
+         ".metadata.number==333 and .spec.number==333"
+      ],
+      "jq_transform": "[.[] | map(.) | .[] | .number ] | add as $sum | [{metadata: {uid: \"uuuu-iiii-dddd\", resourceVersion: \"12345\", sum: $sum}}]"
+    }
+  }
+}


### PR DESCRIPTION
Wrapped all custom jq filter expressions provided by the user's
configuration in `(...)`.  Prior to this, if the user's expression
included a pipe `|` operator, it would break the filter join.
The workaround would force the user to wrap all of his
expressions in a `(...)` in his resource config, which is a little
verbose and repetitive (not to mention annoying).

Now, it's handled automatically.  This doesn't cause any problems if the
user also provides his own `(...)` wrapping, so this is a
backwards compatible "fix".

Also polished the README section discussing the jq filter.  It was a
bit confusing, and had a few spelling and grammar errors.