### PR TITLE
Support `--selector` filter expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ with a general purpose `put` for running any `kubectl` command.
   For `check`/`get`, this will default to all namespaces (`--all-namespaces`). \
   For `put`, this will default to remaining unset (not specified), but can be overridden with a step param (see [below](#out-execute-a-kubectl-command)).
 * `filter`: _Optional_. Can contain any/all of the following criteria:
+  * `selector`: Specify a label `--selector` for the query.  Can use any valid [label selector expression](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).  Defaults to empty.
+    ```yaml
+    source:
+      filter:
+        selector: app=my-app,app.kubernetes.io/component in (frontend, backend)
+    ```
+    **Note:** _Selectors are the only filter that are performed server-side, and can help cull down the response before it passes through the rest of the filters (below).
+  This can speed up `check` operations when dealing with a potentially large volume of resources._ 
   * `name`: Matches against the `metadata.name` of the resource.  Supports both literal (`my-ns-1`) and regular expressions (`"my-ns-[0-9]*$"`).
     ```yaml
     source:

--- a/assets/check
+++ b/assets/check
@@ -29,8 +29,8 @@ queryForVersions() {
         log "${red}Warning:${reset}  No namespace configured!  Defaulting to ${blue}--all-namespaces${reset}."
         namespace_arg="--all-namespaces"
     fi
-    log -p "\n--> querying k8s cluster ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset} for ${yellow}${source_resource_types}${reset} resources..."
-    new_versions=$(kubectl --server=${source_url} --token=${source_token} ${certificate_arg}  get ${source_resource_types} ${namespace_arg} --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' ) || exit $1
+    log -p "\n--> querying k8s cluster ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset} for ${yellow}${source_resource_types}${reset} resources with selector ${cyan}${source_filter_selector}${reset}..."
+    new_versions=$(kubectl --server=${source_url} --token=${source_token} ${certificate_arg} get ${source_resource_types} ${namespace_arg} --selector="${source_filter_selector}" --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' ) || exit $1
     log "$new_versions"
 }
 

--- a/assets/common
+++ b/assets/common
@@ -108,6 +108,9 @@ source_namespace=$(jq -r '.source.namespace | select(.!=null)' < $payload)
 source_sensitive=$(jq -r '.source.sensitive | select(.!=null)' < $payload)
 source_insecure_skip_tls_verify=$(jq -r '.source.insecure_skip_tls_verify // false' < $payload)
 
+# source filter config
+source_filter_selector=$(jq -r '.source.filter.selector | select(. != null)' < $payload)
+
 # params config
 params_kubectl=$(jq -r '.params.kubectl  | select(.!=null)' < $payload)
 params_namespace=$(jq -r '.params.namespace  | select(.!=null)' < $payload)

--- a/test/fixtures/stdin-source-filter-selector.json
+++ b/test/fixtures/stdin-source-filter-selector.json
@@ -1,0 +1,7 @@
+{
+  "source": {
+    "filter": {
+      "selector": "app=my-app"
+    }
+  }
+}


### PR DESCRIPTION
You can now configure a `--selector` to use when querying the cluster
from `check`.

```yaml
source:
  filter:
    selector: app=my-app
```

Any valid label selector(s) can be specified, including combinations
using a comma separator.

```yaml
source:
  filter:
    selector: app=my-app,app.kubernetes.io/component in (frontend, backend)
```

See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
Closes #21