### PR TITLE
New makefile and github workflows for releasing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,13 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Run tests
+    name: Unit Tests
     runs-on: ubuntu-latest
 
     steps:
       - name: checkout
         uses: actions/checkout@v2
-
-      - name: bats tests
-        run: ./test/run.sh -v
+      - name: build
+        run: make build
+      - name: test
+        run: make test

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,0 +1,25 @@
+name: Latest
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Update 'latest'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: build latest
+        run: make build_latest
+      - name: test latest
+        run: make test_latest
+      - name: login to docker hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: push 'latest' to docker hub
+        run: make release_latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: extract tag for release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+      - name: build all image variants
+        run: make build VERSION=$RELEASE_VERSION
+      - name: test all image variants
+        run: make test VERSION=$RELEASE_VERSION
+      - name: login to docker hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: release all image variants to docker hub
+        run: make release VERSION=$RELEASE_VERSION

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Issues and Pull Requests
+
+For small changes or quick fixes, a simple [pull request](https://github.com/jgriff/k8s-resource/pulls) is sufficient.
+
+For non-trivial changes or bug reports, please file an [issue](https://github.com/jgriff/k8s-resource/issues) _before_ submitting a pull request.
+
+For substantial changes, or to discuss a feature request, prefix your issue with "RFC:" (Request For Comment) and tag it with the label [`rfc`](https://github.com/jgriff/k8s-resource/labels/rfc).  
+
+## Development
+
+Build local `dev` images of all `kubectl` variants (`dev-kubectl-<each-k8s-version>`):
+```shell
+make build
+```
+
+Build a single, specific `kubectl` variant (`dev-kubectl-1.22`):
+```shell
+make build_1.22
+```
+
+Run unit tests across all `dev` image variants:
+```shell
+make test
+```
+
+Test a single, specific variant:
+```shell
+make test_1.22
+```
+
+Combine targets in single invocation:
+```shell
+make build_1.22 test_1.22
+```
+
+## Releases
+
+Image releases to Docker Hub are performed by GitHub Actions whenever a new `v*` tag is created.  The leading `v` will be stripped when creating the Docker tag.
+
+Each release ships a set of image variants for a range of `kubectl` versions following the pattern `<tag>-kubectl-<kubectl-version>`, where `<kubectl-version>` will be the `major.minor.patch` that we are shipping along with `major.minor` (tag moves with latest patch) 
+
+For example, tagging the repo with `v1.2.3` will build and publish:
+
+* `1.2.3-kubectl-<major>.<minor>.<patch>` 
+* `1.2.3-kubectl-<major>.<minor>`
+
+See the [`Makefile`](Makefile) for list of all current `kubectl` versions we are supporting.
+
+The `latest` tag always represents the latest state of the `master` branch.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM bitnami/kubectl:1.20
+ARG KUBECTL_VERSION=1.20
+FROM bitnami/kubectl:$KUBECTL_VERSION
 
 USER root
 RUN apt-get update && apt-get -y install --no-install-recommends jq

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,85 @@
+# ######################################################################################################################
+# Globals
+# ######################################################################################################################
+SHELL = /bin/bash
+
+COLOR_RED=\033[0;31m
+COLOR_GREEN=\033[0;32m
+COLOR_ORANGE=\033[0;33m
+COLOR_BLUE=\033[0;34m
+COLOR_PURPLE=\033[0;35m
+COLOR_TEAL=\033[0;36m
+COLOR_WHITE=\033[0;37m
+COLOR_RESET=\033[0m
+
+KUBECTL_1.18=1.18.19
+KUBECTL_1.19=1.19.15
+KUBECTL_1.20=1.20.11
+KUBECTL_1.21=1.21.5
+KUBECTL_1.22=1.22.2
+
+KUBECTL_VERSION=${KUBECTL_1.20}
+
+IMAGE=jgriff/k8s-resource
+VERSION=dev
+
+# ######################################################################################################################
+# Primary goals
+#
+# build - Build all image variants.
+# test - Run all tests against all image variants.
+# release - Release all image variants.
+#
+# ######################################################################################################################
+
+.DEFAULT_GOAL := build
+
+# ---------------------------------------------------------------------------------------
+# build
+# ---------------------------------------------------------------------------------------
+.PHONY: build build_1.18 build_1.19 build_1.20 build_1.21 build_1.22 build_latest
+build: build_1.18 build_1.19 build_1.20 build_1.21 build_1.22 build_latest
+build_1.18: KUBECTL_VERSION=${KUBECTL_1.18}
+build_1.19: KUBECTL_VERSION=${KUBECTL_1.19}
+build_1.20: KUBECTL_VERSION=${KUBECTL_1.20}
+build_1.21: KUBECTL_VERSION=${KUBECTL_1.21}
+build_1.22: KUBECTL_VERSION=${KUBECTL_1.22}
+build_1.18 build_1.19 build_1.20 build_1.21 build_1.22: TAG=${VERSION}-kubectl-${KUBECTL_VERSION}
+build_1.18 build_1.19 build_1.20 build_1.21 build_1.22:
+	@echo -e "\n[${COLOR_BLUE}build${COLOR_RESET}/${COLOR_TEAL}${TAG}${COLOR_RESET}] ${COLOR_ORANGE}Building image${COLOR_RESET}..."
+	@docker build --build-arg KUBECTL_VERSION=${KUBECTL_VERSION} -t ${IMAGE}:${TAG} -t ${IMAGE}:$(shell echo ${TAG} | rev | cut -d '.' -f2- | rev ) .
+build_latest:
+	@echo -e "\n[${COLOR_BLUE}build${COLOR_RESET}/${COLOR_TEAL}latest${COLOR_RESET}] ${COLOR_ORANGE}Building image${COLOR_RESET}..."
+	@docker build -t ${IMAGE} .
+
+
+# ---------------------------------------------------------------------------------------
+# test
+# ---------------------------------------------------------------------------------------
+.PHONY: test test_1.18 test_1.19 test_1.20 test_1.21 test_1.22 test_latest
+test: test_1.18 test_1.19 test_1.20 test_1.21 test_1.22 test_latest
+test_1.18: TAG=${VERSION}-kubectl-${KUBECTL_1.18}
+test_1.19: TAG=${VERSION}-kubectl-${KUBECTL_1.19}
+test_1.20: TAG=${VERSION}-kubectl-${KUBECTL_1.20}
+test_1.21: TAG=${VERSION}-kubectl-${KUBECTL_1.21}
+test_1.22: TAG=${VERSION}-kubectl-${KUBECTL_1.22}
+test_latest: TAG=latest
+test_1.18 test_1.19 test_1.20 test_1.21 test_1.22 test_latest:
+	@echo -e "\n[${COLOR_BLUE}test${COLOR_RESET}/${COLOR_TEAL}${TAG}${COLOR_RESET}] ${COLOR_ORANGE}Testing image${COLOR_RESET}..."
+	@./test/run.sh -i ${IMAGE}:${TAG} -v
+
+# ---------------------------------------------------------------------------------------
+# release
+# ---------------------------------------------------------------------------------------
+.PHONY: release release_1.18 release_1.19 release_1.20 release_1.21 release_1.22 release_latest
+release: release_1.18 release_1.19 release_1.20 release_1.21 release_1.22 release_latest
+release_1.18: TAG=${VERSION}-kubectl-${KUBECTL_1.18}
+release_1.19: TAG=${VERSION}-kubectl-${KUBECTL_1.19}
+release_1.20: TAG=${VERSION}-kubectl-${KUBECTL_1.20}
+release_1.21: TAG=${VERSION}-kubectl-${KUBECTL_1.21}
+release_1.22: TAG=${VERSION}-kubectl-${KUBECTL_1.22}
+release_latest: TAG=latest
+release_1.18 release_1.19 release_1.20 release_1.21 release_1.22 release_latest:
+	@echo -e "\n[${COLOR_BLUE}release${COLOR_RESET}/${COLOR_TEAL}${TAG}${COLOR_RESET}] ${COLOR_ORANGE}Pushing image${COLOR_RESET}..."
+	@docker push ${IMAGE}:${TAG}
+	@docker push ${IMAGE}:$(shell echo ${TAG} | rev | cut -d '.' -f2- | rev )

--- a/test/README.md
+++ b/test/README.md
@@ -24,6 +24,8 @@ This will:
 
 The `run.sh` script also supports options for running a subset of the tests, and an interactive shell for adhoc manual
 testing (ideal for local development iterations).
+         
+**Note:** _You can also run these tests from our [`Makefile`](../Makefile) targets, which is what our CI and Release pipelines use.  Run `make test` to run all tests across all `kubectl` variants, or `make test_<kubectl-version>` for a single version, `make test_latest` to test the `latest`.  However, the "test shell" approach (below) is still the best for fast/iterative development._
 
 ### Running Selective Tests
 


### PR DESCRIPTION
Added a new `Makefile` to simplify and standardize the build/test/release of our images.

To build all image variants:
```
make build
```

To test all image variants:
```
make test
```

To push all image variants to Docker Hub:
```
make release
```
**Note:**  _Only those with push access to `jgriff/k8s-resource` can run these targets (successfully)._

You can also run each of these targets for a single variant version by appending `_<kubectl-version>` to the target name.  For example:
```
make build_1.20
```

Lastly, this commit also introduces a new "Release" GitHub workflow (`.github/workflows/release.yml`) for building and releasing images to Docker Hub whenever the repo is tagged with a tag starting with `v`.  The image is tagged without the leading `v`.  

There's also a new "Latest" action (`github/workflows/latest.yml`) that releases a `latest` image of the default `docker build` from the `master` branch whenever it receives a `push`.

See the new `CONTRIBUTING.md` for more details.