### PR TITLE
Run CI action only for branch pushes and pull requests (not tags)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*' # ignore all tags, our 'release' action triggers on tags
+
 
 jobs:
   test:


### PR DESCRIPTION
Limited the `on.push` event to not also trigger for tags, as the
`release.yml` pipeline handles those events and we don't need/want to
trigger the CI pipeline for a release build.