### PR TITLE
Wait for cluster conditions on PUT

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -232,6 +232,8 @@ The conditions are given each resource's root JSON object.
 * All conditions must produce at least one `true` result, and no `false` results.
 * If the `timeout` is reached before the conditions are satisfied, `put` will fail.
 
+IMPORTANT: Be sure to craft your expressions to safely filter out or ignore any resources you don't care about, taking note of the `resource_types` you are querying for.  _Any `false` result will in any condition will prevent the wait from succeeding._
+
 ===== Default Wait Conditions
 
 If no `conditions` are given, wait will attempt to infer sensible default conditions based on the `resource_types`.
@@ -416,9 +418,9 @@ jobs:
 This will:
 
 . Apply our deployment from `deploy.yaml`.
-. Then wait at most 2 minutes for all deployments to reach a ready state (default condition for `deployment` resource types) who:
-* name starts with `"my-"`
-* have a metadata label `"app.kubernetes.io/component"` of either `"frontend"` or `"backend"` to reach a ready state.
+. Then wait at most 2 minutes for all deployments to reach a ready state (default condition for `deployment` resource types) whose:
+* name starts with `"my-"`.
+* have a metadata label `"app.kubernetes.io/component"` of either `"frontend"` or `"backend"`.
 
 
 === `put` with `await` custom conditions

--- a/README.adoc
+++ b/README.adoc
@@ -204,6 +204,57 @@ the command based on the `source` configuration.
 
 * `namespace`: _Optional._  Overrides the source configuration's value for this particular `put` step.
 
+* `await`: _Optional._  Configures the `put` step to poll the cluster (after running the `kubectl` command) for resources and await certain conditions before succeeding.  Has the following configuration:
+** `timeout`: _Required_. Must be a positive integer to enable waiting (anything else disables waiting). Measured in seconds.
+** `interval`: _Optional_.  Polling interval, measured in seconds (defaults to `3`).
+** `resource_types`: _Optional_. Overrides the source config `resources_types` for what to retrieve from the cluster and run through the `conditions`.
+** `conditions`: _Optional_. List of zero or more `jq` expressions to evaluate. If none are given, default expressions are inferred based on the `resource_types` being retrieved.
+
+==== Wait Conditions
+
+Wait conditions are expressed as `jq` expressions listed under `await.conditions` in the `put` step `params` (similar to the `filter.jq` list in `source` configuration of the resource).
+The conditions are given each resource's root JSON object.
+
+[source,yaml]
+----
+- put: k8s
+  params:
+    kubectl: create deployment my-nginx --image=nginx
+    await:
+      timeout: 30 # seconds
+      resource_types: deployment
+      conditions:
+        - select(.spec.replicas > 0) | .status.readyReplicas > 0
+----
+
+* Can list zero or more conditions (see defaults below for when none are given).
+* Each expression _must_ evaluate to a boolean result (`true` or `false`), all other results are ignored.
+* All conditions must produce at least one `true` result, and no `false` results.
+* If the `timeout` is reached before the conditions are satisfied, `put` will fail.
+
+===== Default Wait Conditions
+
+If no `conditions` are given, wait will attempt to infer sensible default conditions based on the `resource_types`.
+The table below list the conditions that are used by default.
+
+|===
+|`resource_types` |Default Condition
+
+| `pod`, `pods`, `po`
+| `select(.kind == "Pod") \| .status.containerStatuses[] \| .ready`
+
+| `deployment`, `deployments`, `deploy`
+| `select(.kind == "Deployment") \| select(.spec.replicas > 0) \| .spec.replicas == .status.readyReplicas`
+
+| `replicaset`, `replicasets`, `rs`
+| `select(.kind == "ReplicaSet") \| select(.spec.replicas > 0) \| .spec.replicas == .status.readyReplicas`
+
+| `statefulset`, `statefulsets`, `sts`
+| `select(.kind == "StatefulSet") \| select(.spec.replicas > 0) \| .spec.replicas == .status.readyReplicas`
+
+|===
+
+NOTE: The default source config `resource_types` is `pod`.
 
 == Examples
 
@@ -292,7 +343,106 @@ jobs:
           namespace: prod
 ----
 
+=== `put` with `await`
 
+Here's the same example as above, with the added `await` behavior where `put` will wait up to 2 minutes for the deployment to come up.
+If the deployment isn't ready after 2 minutes, `put` will fail.
+
+[source,yaml]
+----
+resource_types:
+  - name: k8s-resource
+    type: docker-image
+    source:
+      repository: jgriff/k8s-resource
+
+resources:
+  - name: k8s
+    type: k8s-resource
+    icon: kubernetes
+    source:
+      url: ((k8s-server))
+      token: ((k8s-token))
+      certificate_authority: ((k8s-ca))
+
+jobs:
+  - name: deploy-prod
+    plan:
+      - get: my-k8s-repo
+        trigger: true
+      - put: k8s
+        params:
+          kubectl: apply -f my-k8s-repo/deploy.yaml
+          namespace: prod
+          await:
+            timeout: 120
+            resource_types: deployment
+----
+
+=== `put` with `await` leveraging check filters
+
+Since `await` uses `check` to retrieve the resources, all the `source.filter` options are available to you when querying for resources to check against your conditions.
+
+For example:
+
+[source,yaml]
+----
+resources:
+  - name: k8s
+    type: k8s-resource
+    icon: kubernetes
+    source:
+      url: ((k8s-server))
+      token: ((k8s-token))
+      certificate_authority: ((k8s-ca))
+      namespace: prod
+      resource_types: deployment
+      filter:
+        selector: app=my-app,app.kubernetes.io/component in (frontend, backend)
+        name: "my-*"
+
+jobs:
+  - name: deploy-prod
+    plan:
+      - get: my-k8s-repo
+        trigger: true
+      - put: k8s
+        params:
+          kubectl: apply -f my-k8s-repo/deploy.yaml
+          await:
+            timeout: 120
+----
+
+This will:
+
+. Apply our deployment from `deploy.yaml`.
+. Then wait at most 2 minutes for all deployments to reach a ready state (default condition for `deployment` resource types) who:
+* name starts with `"my-"`
+* have a metadata label `"app.kubernetes.io/component"` of either `"frontend"` or `"backend"` to reach a ready state.
+
+
+=== `put` with `await` custom conditions
+
+You can supply any custom condition to `await` on.
+
+[source,yaml]
+----
+jobs:
+  - name: deploy-prod
+    plan:
+      - get: my-k8s-repo
+        trigger: true
+      - put: k8s
+        params:
+          kubectl: apply -f my-k8s-repo/deploy.yaml
+          namespace: prod
+          await:
+            timeout: 120
+            resource_types: deployment,statefulset
+            conditions:
+              - select(.metadata.name == "my-deployment") | .status.readyReplicas > 0
+              - select(.metadata.name == "my-statefulset") | .status.readyReplicas > 0
+----
 
 === `get` and `put` Resources
 

--- a/assets/await
+++ b/assets/await
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# -------------------------------------------------------------------------------------
+# await functions - expects 'common' to be already sourced
+
+await() {
+    # await is only enabled if the timeout is configured
+    local await_enabled=$(jq -r '.params.await.timeout > 0' < $payload)
+
+    if isTrue await_enabled; then
+        local await_timeout=$(jq -r '.params.await.timeout' < $payload)
+        local await_interval=$(jq -r '.params.await.interval | select(.!=null)' < $payload)
+
+        # potentially override 'resource_types'
+        local override_resource_types=$(jq -r '.params.await.resource_types | select(.!=null)' < $payload)
+        if isSet override_resource_types; then
+            source_resource_types=$override_resource_types
+        fi
+
+        log -p "\n--> Waiting up to ${yellow}${await_timeout}${reset} seconds for the following condition(s) to be true for resource type(s): ${yellow}$source_resource_types${reset}$(jq --arg nl "\n" --arg color $cyan --arg reset $reset -r '.[] | $nl + "- " + $color + . + $reset' <<< "$(getAwaitConditions)")${reset}"
+
+        awaitLoop $await_timeout $await_interval
+    fi
+}
+
+awaitLoop() {
+  local await_timeout=$1
+  local await_interval=${2:-3}
+
+  local await_started_at=$(date +%s)
+  local await_timeout_at=$((await_started_at + await_timeout))
+
+  local tmp_await_status=$(mktemp)
+  echo "False" > $tmp_await_status
+
+  await_attempts=1
+  until checkAwaitConditions $await_attempts && echo "True" > $tmp_await_status || [ $(date +%s) -gt $await_timeout_at ]
+  do
+      local await_time_left=$(($await_timeout_at - $(date +%s)))
+      local await_time_left_COLOR
+      if [[ $await_time_left -gt 120 ]]; then
+          await_time_left_COLOR=${green}
+      elif [[ $await_time_left -gt 30 ]]; then
+          await_time_left_COLOR=${yellow}
+      else
+          await_time_left_COLOR=${red}
+      fi
+
+      log -p "[$await_attempts]⏳Awaiting cluster conditions, ${await_time_left_COLOR}$(( $await_time_left / 60))m$(( $await_time_left % 60))s${reset} left before giving up..."
+      sleep $await_interval
+      (( await_attempts++ ))
+  done
+
+  local await_elapsed=$(( $(date +%s) - await_started_at))
+  local await_duration_summary="${yellow}$await_attempts${reset} attempt(s) taking ${yellow}$(( $await_elapsed / 60))m$(( $await_elapsed % 60))s${reset}"
+  if [[ $(cat $tmp_await_status) == "True" ]]
+  then
+      log -p "\n${green}Success!${reset} All conditions satisfied after $await_duration_summary!"
+  else
+      log -p "\n${red}Timeout exceeded.${reset} Failed to meet condition(s) after $await_duration_summary."
+      exit 111
+  fi
+}
+
+checkAwaitConditions() {
+    # query for current cluster status
+    local attempt=${1:-1}
+    if [[ $attempt = 1 ]]; then
+        # execute the first check without redirecting output to /dev/null so user can see the query filters being used
+        queryForVersions
+    else
+        queryForVersions &> /dev/null
+    fi
+
+    # check each condition individually
+    local tmp_conditions_results=$(mktemp)
+    jq -r '.[]' <<< "$(getAwaitConditions | tr '\r\n' ' ')" | while read -r condition; do
+        # evaluate this condition, collecting an array of the results
+        local results=($(jq -r ".[] | $condition | select(. == true or . == false)" <<< "$new_versions" | jq -s '.' | jq -r 'map(tostring) | join(" ")'))
+
+        # count up number of true/false matches
+        local trueCount=0
+        local falseCount=0
+        for result in "${results[@]}"; do
+            if isTrue result; then
+                ((trueCount++))
+            else
+                ((falseCount++))
+            fi
+        done
+
+        # color code the printout of the counts
+        local trueCountColor=${red}
+        local falseCountColor=${green}
+        if [ $trueCount -gt 0 ]; then
+            trueCountColor=$green
+        fi
+        if [ $falseCount -gt 0 ]; then
+            falseCountColor=$red
+        fi
+
+        # assert the results from this condition have:
+        # - at least one 'true' value
+        # - no 'false' values
+        # ✘ [true: 0, false: 5]: <condition>
+        # ✘ [true: 2, false: 3]: <condition>
+        # ✔ [true: 5, false: 0]: <condition>
+        resultsStatement="[true: ${trueCountColor}$trueCount${reset}, false: ${falseCountColor}$falseCount${reset}]: ${cyan}$condition${reset}"
+        if [ $trueCount -gt 0 ] && [ $falseCount -eq 0 ]; then
+            log -p "${green}✔${reset} ${resultsStatement}"
+        else
+            log -p "${red}✘${reset} ${resultsStatement}"
+            echo "FAILED" > $tmp_conditions_results
+        fi
+    done
+
+    # now, assert no condition failed
+    if cat $tmp_conditions_results | grep -q 'FAILED'; then
+        return 1
+    fi
+}
+
+getAwaitConditions() {
+    local conditions=$(jq -r '.params.await.conditions | select(.!=null)' < $payload)
+
+    # if no user conditions given, use defaults
+    if notSet conditions; then
+        IFS=',' read -ra active_res_types <<< "$source_resource_types"
+        local default_conditions=()
+
+        if containsElement "po" "${active_res_types[@]}" || \
+           containsElement "pod" "${active_res_types[@]}" || \
+           containsElement "pods" "${active_res_types[@]}"; then
+          default_conditions+=('select(.kind == "Pod") | .status.containerStatuses[] | .ready')
+        fi
+
+        if containsElement "deployment" "${active_res_types[@]}" || \
+           containsElement "deployments" "${active_res_types[@]}" || \
+           containsElement "deploy" "${active_res_types[@]}"; then
+          default_conditions+=('select(.kind == "Deployment") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas')
+        fi
+
+        if containsElement "replicaset" "${active_res_types[@]}" || \
+           containsElement "replicasets" "${active_res_types[@]}" || \
+           containsElement "rs" "${active_res_types[@]}"; then
+          default_conditions+=('select(.kind == "ReplicaSet") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas')
+        fi
+
+        if containsElement "statefulset" "${active_res_types[@]}" || \
+           containsElement "statefulsets" "${active_res_types[@]}" || \
+           containsElement "sts" "${active_res_types[@]}"; then
+          default_conditions+=('select(.kind == "StatefulSet") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas')
+        fi
+
+        # collect all of the enabled default conditions
+        conditions=$(IFS=$'\n'; echo "${default_conditions[*]}" | jq -R . | jq -s '.')
+    fi
+
+    echo "$conditions"
+}

--- a/assets/check
+++ b/assets/check
@@ -8,11 +8,7 @@ exec 1>&2 # redirect all output to stderr for logging
 main() {
     log "\n\n--[CHECK]-------------------------"
     extractPreviousVersion
-    queryForVersions
-    filterByName
-    filterByCreationOlderThan
-    filterByPhases
-    filterByJQExpressions
+    queryAndFilter
     pareDownVersionInfo
     emitResult
 }
@@ -21,71 +17,6 @@ extractPreviousVersion() {
     log "\n--> extracting previous version..."
     previous_version=$(jq -r '.version // ""' < $payload)
     log "previous version: $previous_version"
-}
-
-queryForVersions() {
-    set -o pipefail
-    if notSet namespace_arg; then
-        log "${red}Warning:${reset}  No namespace configured!  Defaulting to ${blue}--all-namespaces${reset}."
-        namespace_arg="--all-namespaces"
-    fi
-    log -p "\n--> querying k8s cluster ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset} for ${yellow}${source_resource_types}${reset} resources with selector ${cyan}${source_filter_selector}${reset}..."
-    new_versions=$(kubectl --server=${source_url} --token=${source_token} ${certificate_arg} get ${source_resource_types} ${namespace_arg} --selector="${source_filter_selector}" --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' ) || exit $1
-    log "$new_versions"
-}
-
-filterByName() {
-    FILTER_NAME=$(jq -r '.source.filter.name // ""' < $payload)
-    if [ ! -z "$FILTER_NAME" ]; then
-        log -p "\n--> filtering by name: ${cyan}$FILTER_NAME${reset}"
-        new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq --arg FILTER_NAME $FILTER_NAME -r '[.[] | select(.metadata.name | test($FILTER_NAME))]')
-        log "$new_versions"
-    else
-        log "\n--> name filter not configured, skipping...."
-    fi
-}
-
-filterByCreationOlderThan() {
-    FILTER_OLDER_THAN=$(jq -r '.source.filter.olderThan // ""' < $payload)
-    if [ ! -z "$FILTER_OLDER_THAN" ]; then
-        log -p "\n--> filtering by creation timestamp older than: ${cyan}$FILTER_OLDER_THAN${reset}"
-        new_versions=$(echo $new_versions  | tr '\r\n' ' ' | jq --argjson MAX_AGE $(( $(date +%s) - $FILTER_OLDER_THAN)) -r '[.[] | select(.metadata.creationTimestamp | fromdate | tonumber | select(. < $MAX_AGE)) ]')
-        log "$new_versions"
-    else
-        log "\n--> creation timestamp (older than) filter not configured, skipping...."
-    fi
-}
-
-filterByPhases() {
-    FILTER_PHASES=$(jq -r '.source.filter.phases // ""' < $payload)
-    if [ ! -z "$FILTER_PHASES" ]; then
-        # remove any duplicates
-        FILTER_PHASES=$(echo "$FILTER_PHASES" | jq 'unique')
-
-        log -p "\n--> filtering by phases: ${cyan}$FILTER_PHASES${reset}"
-        new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq --argjson FILTER_PHASES "$FILTER_PHASES" -r '[.[] | select(.status.phase as $candidate | $FILTER_PHASES[] as $required | $candidate == $required)]')
-        log "$new_versions"
-    else
-        log "\n--> phases filter not configured, skipping...."
-    fi
-}
-
-filterByJQExpressions() {
-    FILTER_OPERATOR=$(jq -r '.source.filter.jq_operator // ","' < $payload)
-    FILTER_TRANSFORM=$(jq -r '.source.filter.jq_transform // ""' < $payload)
-    FILTER_QUERY=$(jq -r ".source.filter.jq // [] | map(\"(\" + . + \")\") | join(\" ${FILTER_OPERATOR} \") // \"\"" < $payload)
-    if [ ! -z "$FILTER_QUERY" ]; then
-        log -p "\n--> filtering by JQ query: ${cyan}$FILTER_QUERY${reset}"
-        if [ -n "$FILTER_TRANSFORM" ]; then
-           FILTER_TRANSFORM="| $FILTER_TRANSFORM"
-           log -p "       with transformation: ${cyan}$FILTER_TRANSFORM${reset}"
-        fi
-        new_versions=$(echo "$new_versions" | tr '\r\n' ' ')
-        new_versions=$(echo "$new_versions" | jq -r "[.[] | select( $FILTER_QUERY ) ] | unique $FILTER_TRANSFORM")
-        log "$new_versions"
-    else
-        log "\n--> jq filter not configured, skipping...."
-    fi
 }
 
 pareDownVersionInfo() {
@@ -113,5 +44,6 @@ emitResult() {
 
 if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
     source $(dirname $0)/common
+    source $(dirname $0)/query
     main "$@"
 fi

--- a/assets/common
+++ b/assets/common
@@ -3,6 +3,7 @@
 # colors
 export esc=$(printf '\033')
 export red=${esc}$(printf '[31m')
+export green=${esc}$(printf '[32m')
 export yellow=${esc}$(printf '[33m')
 export blue=${esc}$(printf '[34m')
 export cyan=${esc}$(printf '[36m')
@@ -83,6 +84,14 @@ isSensitive() {
     if isTrue params_sensitive; then return 0; fi
     if isTrue source_sensitive && notSet params_sensitive; then return 0; fi
     return 1;
+}
+
+# usage: containsElement "candidate" "${the_array_to_test[@]}"
+containsElement () {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
 }
 
 namespace() {

--- a/assets/out
+++ b/assets/out
@@ -9,6 +9,7 @@ main() {
     log "\n\n--[OUT]-------------------------"
     sourcesDirectory $1
     invokeKubectl
+    await
     emitResult
 }
 
@@ -23,7 +24,7 @@ invokeKubectl() {
         log -p "${red}Warning:${reset}  No namespace configured!"
     fi
 
-    log -p "\n--> Invoking ${cyan}kubectl${reset} with args ${yellow}${params_kubectl}${reset} targeting cluster at ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset}..."
+    log -p "\n--> Invoking ${yellow}kubectl${reset} with args ${yellow}${params_kubectl}${reset} targeting cluster at ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset}..."
     kubectl --server=${source_url} --token=${source_token} ${certificate_arg} ${namespace_arg} ${params_kubectl}
 }
 
@@ -44,5 +45,7 @@ emitResult() {
 
 if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
     source $(dirname $0)/common
+    source $(dirname $0)/query
+    source $(dirname $0)/await
     main "$@"
 fi

--- a/assets/query
+++ b/assets/query
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# -------------------------------------------------------------------------------------
+# cluster query functions - expects 'common' to be already sourced
+
+queryAndFilter() {
+    queryForVersions
+    filterByName
+    filterByCreationOlderThan
+    filterByPhases
+    filterByJQExpressions
+}
+
+queryForVersions() {
+    set -o pipefail
+    if notSet namespace_arg; then
+        log "${red}Warning:${reset}  No namespace configured!  Defaulting to ${blue}--all-namespaces${reset}."
+        namespace_arg="--all-namespaces"
+    fi
+    log -p "\n--> querying k8s cluster ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset} for ${yellow}${source_resource_types}${reset} resources with selector ${cyan}${source_filter_selector}${reset}..."
+    new_versions=$(kubectl --server=${source_url} --token=${source_token} ${certificate_arg} get ${source_resource_types} ${namespace_arg} --selector="${source_filter_selector}" --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' ) || exit $1
+    log "$new_versions"
+}
+
+filterByName() {
+    local filter_name=$(jq -r '.source.filter.name // ""' < $payload)
+    if [ ! -z "$filter_name" ]; then
+        log -p "--> filtering by name: ${cyan}$filter_name${reset}"
+        new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq --arg filter_name $filter_name -r '[.[] | select(.metadata.name | test($filter_name))]')
+        log "$new_versions"
+    else
+        log "--> name filter not configured, skipping...."
+    fi
+}
+
+filterByCreationOlderThan() {
+    local filter_older_than=$(jq -r '.source.filter.olderThan // ""' < $payload)
+    if [ ! -z "$filter_older_than" ]; then
+        log -p "--> filtering by creation timestamp older than: ${cyan}$filter_older_than${reset}"
+        new_versions=$(echo $new_versions  | tr '\r\n' ' ' | jq --argjson MAX_AGE $(( $(date +%s) - $filter_older_than)) -r '[.[] | select(.metadata.creationTimestamp | fromdate | tonumber | select(. < $MAX_AGE)) ]')
+        log "$new_versions"
+    else
+        log "--> creation timestamp (older than) filter not configured, skipping...."
+    fi
+}
+
+filterByPhases() {
+    local filter_phases=$(jq -r '.source.filter.phases // ""' < $payload)
+    if [ ! -z "$filter_phases" ]; then
+        # remove any duplicates
+        filter_phases=$(echo "$filter_phases" | jq 'unique')
+
+        log -p "--> filtering by phases: ${cyan}$filter_phases${reset}"
+        new_versions=$(echo "$new_versions" | tr '\r\n' ' ' | jq --argjson filter_phases "$filter_phases" -r '[.[] | select(.status.phase as $candidate | $filter_phases[] as $required | $candidate == $required)]')
+        log "$new_versions"
+    else
+        log "--> phases filter not configured, skipping...."
+    fi
+}
+
+filterByJQExpressions() {
+    local filter_operator=$(jq -r '.source.filter.jq_operator // ","' < $payload)
+    local filter_transform=$(jq -r '.source.filter.jq_transform // ""' < $payload)
+    local filter_query=$(jq -r ".source.filter.jq // [] | map(\"(\" + . + \")\") | join(\" ${filter_operator} \") // \"\"" < $payload)
+    if [ ! -z "$filter_query" ]; then
+        log -p "--> filtering by JQ query: ${cyan}$filter_query${reset}"
+        if [ -n "$filter_transform" ]; then
+           filter_transform="| $filter_transform"
+           log -p "       with transformation: ${cyan}$filter_transform${reset}"
+        fi
+        new_versions=$(echo "$new_versions" | tr '\r\n' ' ')
+        new_versions=$(echo "$new_versions" | jq -r "[.[] | select( $filter_query ) ] | unique $filter_transform")
+        log "$new_versions"
+    else
+        log "--> jq filter not configured, skipping...."
+    fi
+}

--- a/test/await.bats
+++ b/test/await.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+
+load '/opt/bats/addons/bats-support/load.bash'
+load '/opt/bats/addons/bats-assert/load.bash'
+load '/opt/bats/addons/bats-mock/stub.bash'
+
+source_await() {
+    stdin_payload=${1:-"stdin-source"}
+
+    # source the common script
+    source "$SUT_ASSETS_DIR/common" <<< "$(<$BATS_TEST_DIRNAME/fixtures/$stdin_payload.json)"
+
+    # stub the log function
+    log() { echo "$@"; } # use this during development to see log output
+#    log() { :; }
+    export -f log
+
+    # source the sut
+    source "$SUT_ASSETS_DIR/await"
+}
+
+@test "[await] GH-19 await is enabled if timeout is configured" {
+    source_await "stdin-params-await"
+
+    # stub 'awaitLoop' to expect to be called with our timeout
+    invoked=false
+    awaitLoop() { invoked=true; }
+    export -f awaitLoop
+
+    await
+
+    # verify 'awaitLoop' was called
+    assert_equal $invoked true
+}
+
+@test "[await] GH-19 await is NOT enabled if timeout is <= 0" {
+    source_await "stdin-params-await-disabled"
+
+    # stub 'awaitLoop' to expect to be called with our timeout
+    invoked=false
+    awaitLoop() { invoked=true; }
+    export -f awaitLoop
+
+    await
+
+    # verify 'awaitLoop' was called
+    assert_equal $invoked false
+}
+
+@test "[await] GH-19 getAwaitConditions() returns the explicitly configured conditions" {
+    source_await "stdin-params-await"
+
+    run getAwaitConditions
+
+    assert_line --partial '"select(.kind == \"Pod\") | .status.containerStatuses[] | .ready"'
+    assert_line --partial '"select(.kind == \"Deployment\") | select(.spec.replicas > 0) | .status.readyReplicas > 0"'
+}
+
+@test "[await] GH-19 getAwaitConditions() returns default conditions for the default 'resource_types'" {
+    source_await "stdin-params-await-no-conditions"
+
+    run getAwaitConditions
+
+    # 'pods' are the default resource_types
+    assert_line --partial '"select(.kind == \"Pod\") | .status.containerStatuses[] | .ready"'
+}
+
+@test "[await] GH-19 getAwaitConditions() returns default conditions for 'pod' 'resource_types'" {
+    source_await "stdin-params-await-no-conditions"
+
+    for type in "pod" "pods" "po"; do
+        source_resource_types=$type
+
+        run getAwaitConditions
+
+        assert_line --partial '"select(.kind == \"Pod\") | .status.containerStatuses[] | .ready"'
+    done
+}
+
+@test "[await] GH-19 getAwaitConditions() returns default conditions for 'deployment' 'resource_types'" {
+    source_await "stdin-params-await-no-conditions"
+
+    for type in "deployment" "deployments" "deploy"; do
+        source_resource_types=$type
+
+        run getAwaitConditions
+
+        assert_line --partial '"select(.kind == \"Deployment\") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas"'
+    done
+}
+
+@test "[await] GH-19 getAwaitConditions() returns default conditions for 'replicaset' 'resource_types'" {
+    source_await "stdin-params-await-no-conditions"
+
+    for type in "replicaset" "replicasets" "rs"; do
+        source_resource_types=$type
+
+        run getAwaitConditions
+
+        assert_line --partial '"select(.kind == \"ReplicaSet\") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas"'
+    done
+}
+
+@test "[await] GH-19 getAwaitConditions() returns default conditions for 'statefulset' 'resource_types'" {
+    source_await "stdin-params-await-no-conditions"
+
+    for type in "statefulset" "statefulsets" "sts"; do
+        source_resource_types=$type
+
+        run getAwaitConditions
+
+        assert_line --partial '"select(.kind == \"StatefulSet\") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas"'
+    done
+}
+
+@test "[await] GH-19 getAwaitConditions() returns combined default conditions for 'resource_types'" {
+    source_await "stdin-params-await-no-conditions"
+
+    source_resource_types="pod,deployment,rs,sts"
+
+    run getAwaitConditions
+
+    assert_line --partial '"select(.kind == \"Pod\") | .status.containerStatuses[] | .ready"'
+    assert_line --partial '"select(.kind == \"Deployment\") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas"'
+    assert_line --partial '"select(.kind == \"ReplicaSet\") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas"'
+    assert_line --partial '"select(.kind == \"StatefulSet\") | select(.spec.replicas > 0) | .spec.replicas == .status.readyReplicas"'
+}
+
+@test "[await] GH-19 checkAwaitConditions() succeeds when all conditions are met" {
+    source_await "stdin-params-await"
+
+    # stub 'queryForVersions' to do nothing (we'll set 'new_versions' ourselves)
+    stub queryForVersions
+
+    # set the 'new_versions' variable with some mock data that would have been returned from our kubectl query
+    new_versions='[
+      {
+        "kind": "Pod",
+        "status": {
+          "containerStatuses": [
+            {
+              "ready": true
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Pod",
+        "status": {
+          "containerStatuses": [
+            {
+              "ready": true
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Deployment",
+        "spec": {
+          "replicas": 2
+        },
+        "status": {
+          "readyReplicas": 1
+        }
+      }
+    ]'
+
+    # invoke the sut
+    run checkAwaitConditions
+
+    # conditions should succeed
+    assert_success
+}
+
+@test "[await] GH-19 checkAwaitConditions() fails when just one condition is not met" {
+    source_await "stdin-params-await"
+
+    # stub 'queryForVersions' to do nothing (we'll set 'new_versions' ourselves)
+    stub queryForVersions
+
+    # set the 'new_versions' variable with some mock data that would have been returned from our kubectl query
+    new_versions='[
+      {
+        "kind": "Pod",
+        "status": {
+          "containerStatuses": [
+            {
+              "ready": true
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Pod",
+        "status": {
+          "containerStatuses": [
+            {
+              "ready": false
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Deployment",
+        "spec": {
+          "replicas": 2
+        },
+        "status": {
+          "readyReplicas": 1
+        }
+      }
+    ]'
+
+    # invoke the sut
+    run checkAwaitConditions
+
+    # conditions should succeed
+    assert_failure
+}

--- a/test/check.bats
+++ b/test/check.bats
@@ -31,6 +31,7 @@ source_check() {
     fi
 
     # source the sut
+    source "$SUT_ASSETS_DIR/query"
     source "$SUT_ASSETS_DIR/check"
 }
 

--- a/test/fixtures/stdin-params-await-disabled.json
+++ b/test/fixtures/stdin-params-await-disabled.json
@@ -1,0 +1,11 @@
+{
+  "params": {
+    "await": {
+      "timeout": 0,
+      "conditions": [
+        "select(.kind == \"Pod\") | .status.containerStatuses[] | .ready",
+        "select(.kind == \"Deployment\") | select(.spec.replicas > 0) | .status.readyReplicas > 0"
+      ]
+    }
+  }
+}

--- a/test/fixtures/stdin-params-await-no-conditions.json
+++ b/test/fixtures/stdin-params-await-no-conditions.json
@@ -1,0 +1,7 @@
+{
+  "params": {
+    "await": {
+      "timeout": 10
+    }
+  }
+}

--- a/test/fixtures/stdin-params-await.json
+++ b/test/fixtures/stdin-params-await.json
@@ -1,0 +1,11 @@
+{
+  "params": {
+    "await": {
+      "timeout": 10,
+      "conditions": [
+        "select(.kind == \"Pod\") | .status.containerStatuses[] | .ready",
+        "select(.kind == \"Deployment\") | select(.spec.replicas > 0) | .status.readyReplicas > 0"
+      ]
+    }
+  }
+}

--- a/test/out.bats
+++ b/test/out.bats
@@ -16,6 +16,7 @@ source_out() {
     export -f log
 
     # source the sut
+    source "$SUT_ASSETS_DIR/await"
     source "$SUT_ASSETS_DIR/out"
 }
 
@@ -123,4 +124,32 @@ source_out() {
 
     # should emit the output of kubectl
     assert_equal "$output" 'stuff the k8s server sends back'
+}
+
+@test "[out] GH-19 await is enabled if timeout is configured" {
+    source_out "stdin-params-await"
+
+    # stub 'awaitLoop' to expect to be called with our timeout
+    invoked=false
+    awaitLoop() { invoked=true; }
+    export -f awaitLoop
+
+    await
+
+    # verify 'awaitLoop' was called
+    assert_equal $invoked true
+}
+
+@test "[out] GH-19 await is NOT enabled if timeout is <= 0" {
+    source_out "stdin-params-await-disabled"
+
+    # stub 'awaitLoop' to expect to be called with our timeout
+    invoked=false
+    awaitLoop() { invoked=true; }
+    export -f awaitLoop
+
+    await
+
+    # verify 'awaitLoop' was called
+    assert_equal $invoked false
 }


### PR DESCRIPTION
New Feature!  Added support for waiting for cluster conditions after a
`put` step.  You can now (optionally) configure a `put` to wait for the
cluster to satisfy specific conditions before the step will succeed.

To enable this, simply specify an `await.timeout` param to your `put`
step:
```yaml
  params:
    await:
      timeout: 30
```

The `timeout` is measured in seconds, and must be greater than `0` to
enable waiting.

The conditions to wait for are specified in `await.conditions` as a
list:
```yaml
  params:
    await:
      timeout: 30
      conditions:
        - select(.kind == "Pod") | .status.containerStatuses[] | .ready
```
You can include any number of conditions.  In order for the wait to
succeed each expression must evaluate to at least _one_ `true` result,
and no `false` results.  Any other non `true|false` result is ignored.

If no `conditions` are specified, sensible defaults are used for the
resource types being retrieved.

If the `timeout` is exceeded before all conditions are met, the `put`
will fail.

See the updated `README` for further details.
Closes #19