### PR TITLE
Add Makefile target `test_shell` to launch a bats test shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,11 @@ test_1.18 test_1.19 test_1.20 test_1.21 test_1.22 test_latest:
 	@echo -e "\n[${COLOR_BLUE}test${COLOR_RESET}/${COLOR_TEAL}${TAG}${COLOR_RESET}] ${COLOR_ORANGE}Testing image${COLOR_RESET}..."
 	@./test/run.sh -i ${IMAGE}:${TAG} -v
 
+.PHONY: test_shell
+test_shell:
+	@echo -e "[${COLOR_BLUE}test${COLOR_RESET}/${COLOR_TEAL}shell${COLOR_RESET}] ${COLOR_ORANGE}Launching test shell${COLOR_RESET}..."
+	@./test/run.sh shell
+
 # ---------------------------------------------------------------------------------------
 # release
 # ---------------------------------------------------------------------------------------

--- a/test/README.md
+++ b/test/README.md
@@ -58,6 +58,11 @@ the tests yourself.
 ./run.sh shell
 ```
 
+There's also a [`Makefile`](../Makefile) target for it (from the root of the project).
+
+```bash
+make test_shell
+```
 
 
 This will build the resource and test image as usual, but instead of running the tests and exiting it will drop you into

--- a/test/run.sh
+++ b/test/run.sh
@@ -177,6 +177,14 @@ runTests() {
 
 openShellSession() {
     echo "${icon_shell_session} ${blue}Opening${reset} shell session in ${yellow}${TEST_IMAGE}${reset} container ..."
+    echo -e "\nUsage:"
+    echo -e "    bats <tests-to-run>"
+    echo -e "Examples:"
+    echo -e "    bats test             - run all tests"
+    echo -e "    bats test/check.bats  - run all tests for 'check'"
+    echo -e "    bats test/in.bats     - run all tests for 'in'"
+    echo -e "    bats test/out.bats    - run all tests for 'out'"
+    echo -e ""
     docker run --rm -it -v ${PROJECT_HOME}:/code -w /code -e SUT_ASSETS_DIR=/code/assets --entrypoint /bin/bash ${TEST_IMAGE}
     TEST_RESULT=shell
 }


### PR DESCRIPTION
Added a convenient make target for launching the interactive test shell.
```
make test_shell
```

This is essentially a shortcut for:
```
test/run.sh shell
```

Also added some helpful usage info that is echo'd out just before the
shell opens.