### PR TITLE
Build multi-arch images

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -16,6 +16,13 @@ jobs:
         run: make build_latest
       - name: test latest
         run: make test_latest
+      - name: setup qemu (to run builders other than host)
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: setup buildx (used by our 'release_latest' makefile target for multi-arch releases)
+        id: buildx
+        uses: docker/setup-buildx-action@master
       - name: login to docker hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ jobs:
         run: make build VERSION=$RELEASE_VERSION
       - name: test all image variants
         run: make test VERSION=$RELEASE_VERSION
+      - name: setup qemu (to run builders other than host)
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: setup buildx (used by our 'release' makefile target for multi-arch releases)
+        id: buildx
+        uses: docker/setup-buildx-action@master
       - name: login to docker hub
         uses: docker/login-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -86,5 +86,7 @@ release_1.22: TAG=${VERSION}-kubectl-${KUBECTL_1.22}
 release_latest: TAG=latest
 release_1.18 release_1.19 release_1.20 release_1.21 release_1.22 release_latest:
 	@echo -e "\n[${COLOR_BLUE}release${COLOR_RESET}/${COLOR_TEAL}${TAG}${COLOR_RESET}] ${COLOR_ORANGE}Pushing image${COLOR_RESET}..."
-	@docker push ${IMAGE}:${TAG}
-	@docker push ${IMAGE}:$(shell echo ${TAG} | rev | cut -d '.' -f2- | rev )
+	@docker buildx create --name k8s-resource-builder
+	@docker buildx build --builder k8s-resource-builder --platform linux/amd64,linux/arm64/v8 --push --tag ${IMAGE}:$(shell echo ${TAG} | rev | cut -d '.' -f2- | rev ) .
+	@docker buildx build --builder k8s-resource-builder --platform linux/amd64,linux/arm64/v8 --push --tag ${IMAGE}:${TAG} .
+	@docker buildx rm k8s-resource-builder


### PR DESCRIPTION
Added `buildx` to all Makefile and CI builds (latest and release) so we
always build multi-arch images.

You can build and push `latest` for `linux/amd64` and `linux/arm64/v8` with:
```
make release_latest
```

Otherwise, tagging of the repo continues to trigger CI builds of the
tagged version and will now publish the image for both `linux/amd64`
and `linux/arm64/v8` architectures.