### PR TITLE
Add `youngerThan` filter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,6 +77,15 @@ source:
     olderThan: 86400
 ----
 
+** `youngerThan`: Time in seconds that the `metadata.creationTimestamp` must be younger than (ex: `3600` for 1hr).
++
+[source,yaml]
+----
+source:
+  filter:
+    youngerThan: 3600
+----
+
 ** `phases`: List of `status.phase` value(s) the resource must match at least one of.  This varies depending on the resource.
 For example, a https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase[pod's status] can be one of `Pending`, `Running`, `Succeeded`, `Failed` or `Unknown`.
 To retrieve only `Failed` or `Unknown` pods:

--- a/assets/query
+++ b/assets/query
@@ -7,6 +7,7 @@ queryAndFilter() {
     queryForVersions
     filterByName
     filterByCreationOlderThan
+    filterByCreationYoungerThan
     filterByPhases
     filterByJQExpressions
 }
@@ -41,6 +42,17 @@ filterByCreationOlderThan() {
         log "$new_versions"
     else
         log "--> creation timestamp (older than) filter not configured, skipping...."
+    fi
+}
+
+filterByCreationYoungerThan() {
+    local filter_younger_than=$(jq -r '.source.filter.youngerThan // ""' < $payload)
+    if [ ! -z "$filter_younger_than" ]; then
+        log -p "--> filtering by creation timestamp younger than: ${cyan}$filter_younger_than${reset}"
+        new_versions=$(echo $new_versions  | tr '\r\n' ' ' | jq --argjson MIN_AGE $(( $(date +%s) - $filter_younger_than)) -r '[.[] | select(.metadata.creationTimestamp | fromdate | tonumber | select(. > $MIN_AGE)) ]')
+        log "$new_versions"
+    else
+        log "--> creation timestamp (younger than) filter not configured, skipping...."
     fi
 }
 

--- a/test/fixtures/stdin-source-filter-youngerThan-olderThan.json
+++ b/test/fixtures/stdin-source-filter-youngerThan-olderThan.json
@@ -1,0 +1,8 @@
+{
+  "source": {
+    "filter": {
+      "olderThan": 3000,
+      "youngerThan": 80000
+    }
+  }
+}

--- a/test/fixtures/stdin-source-filter-youngerThan.json
+++ b/test/fixtures/stdin-source-filter-youngerThan.json
@@ -1,0 +1,7 @@
+{
+  "source": {
+    "filter": {
+      "youngerThan": 3600
+    }
+  }
+}


### PR DESCRIPTION
Added support for filtering by creation timestamp that is `youngerThan`
a specified amount of time.

```yaml
source:
  filter:
    youngerThan: 3600
```

This inversely complements the existing filter functionality for
`olderThan`, and can also be used together to define a time window.

For example, resources created between 1 and 2 hours ago:
```yaml
source:
  filter:
    olderThan: 3600
    youngerThan: 7200
```