### PR TITLE
Symlink bitnami kubectl location to standard path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,8 @@ FROM bitnami/kubectl:$KUBECTL_VERSION
 USER root
 RUN apt-get update && apt-get -y install --no-install-recommends jq
 
+# symlink kubectl to the standard path location
+RUN ln -s /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+
 ADD assets /opt/resource/
 RUN chmod +x /opt/resource/*


### PR DESCRIPTION
The bitnami base image adds their location of `kubectl` to the PATH.

```
  PATH=/opt/bitnami/kubectl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

However this PATH location can be lost during a docker export/import of the image, making bundling this resource difficult.

```
  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

To resolve this, we now create a symbolic link in the standard PATH location:

```
  /usr/local/bin/kubectl -> /opt/bitnami/kubectl/bin/kubectl
```

The link is preserved during export/import, so our resource scripts can still locate kubectl even though the bitnami location is no longer on the PATH.

See https://concourse-ci.org/concourse-worker.html#installing-or-upgrading-bundled-resource-types 
Closes #35