### PR TITLE
Support JSON patches

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -40,7 +40,7 @@ fetchResource() {
 
     # fetch the requested resource
     log -p "\n--> Retrieving ${yellow}${source_resource_types}${reset} resource ${cyan}$uid${reset} at version ${cyan}$resourceVersion${reset} from cluster at ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset}..."
-    kubectl --server=${source_url} --token=${source_token} ${certificate_arg} get ${source_resource_types} ${namespace_arg} --sort-by={.metadata.resourceVersion} -o json \
+    eval "kubectl --server=${source_url} --token=${source_token} ${certificate_arg} get ${source_resource_types} ${namespace_arg} --sort-by={.metadata.resourceVersion} -o json" \
           | jq --arg uid ${uid} --arg resourceVersion ${resourceVersion} '.items[] | select((.metadata.uid == $uid and .metadata.resourceVersion == $resourceVersion))' \
      > $target_dir/resource.json
 }

--- a/assets/out
+++ b/assets/out
@@ -25,7 +25,7 @@ invokeKubectl() {
     fi
 
     log -p "\n--> Invoking ${yellow}kubectl${reset} with args ${yellow}${params_kubectl}${reset} targeting cluster at ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset}..."
-    kubectl --server=${source_url} --token=${source_token} ${certificate_arg} ${namespace_arg} ${params_kubectl}
+    eval "kubectl --server=${source_url} --token=${source_token} ${certificate_arg} ${namespace_arg} ${params_kubectl}"
 }
 
 emitResult() {

--- a/assets/query
+++ b/assets/query
@@ -19,7 +19,7 @@ queryForVersions() {
         namespace_arg="--all-namespaces"
     fi
     log -p "\n--> querying k8s cluster ${blue}${source_url}${reset} in namespace ${blue}$(namespace)${reset} for ${yellow}${source_resource_types}${reset} resources with selector ${cyan}${source_filter_selector}${reset}..."
-    new_versions=$(kubectl --server=${source_url} --token=${source_token} ${certificate_arg} get ${source_resource_types} ${namespace_arg} --selector="${source_filter_selector}" --sort-by='{.metadata.resourceVersion}' -o json | jq '[.items[]]' ) || exit $1
+    new_versions=$(eval "kubectl --server=${source_url} --token=${source_token} ${certificate_arg} get ${source_resource_types} ${namespace_arg} --selector=\"${source_filter_selector}\" --sort-by='{.metadata.resourceVersion}' -o json" | jq '[.items[]]' ) || exit $1
     log "$new_versions"
 }
 


### PR DESCRIPTION
Currently trying to use json patches causes a `json: cannot unmarshal string into Go value of type jsonpatch.Patch` error because they require single quotes, and those get escaped to `'\''` by bash. 

This PR fixes that.

The goal is to support things like this:
```yaml
params:
  kubectl: patch application my-app --type=json --patch '[{"op":"remove","path":"/spec/syncPolicy/automated"}]'
```

If you'd like a different solution, let me know and we can adjust.